### PR TITLE
Change modem table to not be a process

### DIFF
--- a/lib/vintage_net_mobile/application.ex
+++ b/lib/vintage_net_mobile/application.ex
@@ -4,11 +4,8 @@ defmodule VintageNetMobile.Application do
   use Application
 
   def start(_type, _args) do
-    env = Application.get_all_env(:vintage_net_mobile)
-
     children = [
-      {VintageNetMobile.ToElixir.Server, "/tmp/vintage_net/pppd_comms"},
-      {VintageNetMobile.Modems, env}
+      {VintageNetMobile.ToElixir.Server, "/tmp/vintage_net/pppd_comms"}
     ]
 
     opts = [strategy: :rest_for_one, name: VintageNetMobile.Supervisor]


### PR DESCRIPTION
This change removes the runtime dependence of an process being up when
`VintageNet` is trying to configure an interface.