### PR TITLE
Add ready callback for modems

### DIFF
--- a/lib/vintage_net_mobile.ex
+++ b/lib/vintage_net_mobile.ex
@@ -70,6 +70,7 @@ defmodule VintageNetMobile do
       source_config: config
     }
     |> modem_implementation.add_raw_config(config, opts)
+    |> add_ready_command(modem_implementation)
   end
 
   @impl true
@@ -78,4 +79,10 @@ defmodule VintageNetMobile do
   # TODO: implement
   @impl true
   def check_system(_), do: :ok
+
+  defp add_ready_command(raw_config, modem_implementation) do
+    new_up_cmds = [{:fun, modem_implementation, :ready, []} | raw_config.up_cmds]
+
+    %RawConfig{raw_config | up_cmds: new_up_cmds}
+  end
 end

--- a/lib/vintage_net_mobile/modem.ex
+++ b/lib/vintage_net_mobile/modem.ex
@@ -20,4 +20,9 @@ defmodule VintageNetMobile.Modem do
   Update the raw configuration for the modem
   """
   @callback add_raw_config(RawConfig.t(), map(), keyword()) :: RawConfig.t()
+
+  @doc """
+  Check to make sure the modem is ready to be used
+  """
+  @callback ready() :: :ok | {:error, :missing_modem}
 end

--- a/lib/vintage_net_mobile/modems/quectel_BG96.ex
+++ b/lib/vintage_net_mobile/modems/quectel_BG96.ex
@@ -67,4 +67,13 @@ defmodule VintageNetMobile.Modems.QuectelBG96 do
     }
     |> PPPDConfig.add_child_spec("ttyUSB3", 9600, opts)
   end
+
+  @impl true
+  def ready() do
+    if File.exists?("/dev/ttyUSB3") do
+      :ok
+    else
+      {:error, :missing_modem}
+    end
+  end
 end

--- a/lib/vintage_net_mobile/modems/quectel_EC25AF.ex
+++ b/lib/vintage_net_mobile/modems/quectel_EC25AF.ex
@@ -34,4 +34,13 @@ defmodule VintageNetMobile.Modems.QuectelEC25AF do
     }
     |> PPPDConfig.add_child_spec("ttyUSB3", 9600, opts)
   end
+
+  @impl true
+  def ready() do
+    if File.exists?("/dev/ttyUSB3") do
+      :ok
+    else
+      {:error, :missing_usb_modem}
+    end
+  end
 end

--- a/test/support/custom_modem.ex
+++ b/test/support/custom_modem.ex
@@ -18,4 +18,7 @@ defmodule VintageNetMobileTest.CustomModem do
       | files: [{"chatscript.#{ifname}", "Service provider is #{config.service_provider}"}]
     }
   end
+
+  @impl true
+  def ready(), do: :ok
 end

--- a/test/support/hacked_up_modem.ex
+++ b/test/support/hacked_up_modem.ex
@@ -19,4 +19,7 @@ defmodule VintageNetMobileTest.HackedUpModem do
       | files: [{"chatscript.#{ifname}", "Bob is awesome"}]
     }
   end
+
+  @impl true
+  def ready(), do: :ok
 end

--- a/test/vintage_net_mobile/modems/quectel_BG96_test.exs
+++ b/test/vintage_net_mobile/modems/quectel_BG96_test.exs
@@ -18,6 +18,7 @@ defmodule VintageNetMobile.Modems.QuectelBG96Test do
       source_config: input,
       require_interface: false,
       up_cmds: [
+        {:fun, QuectelBG96, :ready, []},
         {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
       ],
       files: [

--- a/test/vintage_net_mobile/modems/quectel_EC25AF_test.exs
+++ b/test/vintage_net_mobile/modems/quectel_EC25AF_test.exs
@@ -18,6 +18,7 @@ defmodule VintageNetMobile.Modems.QuectelEC25AFTest do
       source_config: input,
       require_interface: false,
       up_cmds: [
+        {:fun, QuectelEC25AF, :ready, []},
         {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
       ],
       files: [


### PR DESCRIPTION
Added a ready callback for modems to implement. This was added to allow
the modem to define the way it is considered ready. At the same time we
don't force the modem implementer to worry how this is tied into the
VintageNet runtime.

This should fix #18 

Also tested hot plugging in the modem and `VintageNet` was able to pick that up and start `ppp`. Everything worked correctly.