### PR TITLE
Support multiple service provider configurations

### DIFF
--- a/lib/vintage_net_mobile/chatscript.ex
+++ b/lib/vintage_net_mobile/chatscript.ex
@@ -9,8 +9,8 @@ defmodule VintageNetMobile.Chatscript do
   This is useful if all you need is a basic chatscript. If you have more
   complex and custom needs you will not want to use this.
   """
-  @spec default(binary()) :: binary()
-  def default(apn) do
+  @spec default([VintageNetMobile.service_provider_info()]) :: binary()
+  def default(service_providers) do
     """
     ABORT 'BUSY'
     ABORT 'NO CARRIER'
@@ -29,8 +29,7 @@ defmodule VintageNetMobile.Chatscript do
 
     OK ATQ0
 
-    OK AT+CGDCONT=1,"IP","#{apn}"
-
+    #{pdp_contexts(service_providers)}
     OK ATDT*99***1#
 
     CONNECT ''
@@ -43,5 +42,22 @@ defmodule VintageNetMobile.Chatscript do
   @spec path(binary(), keyword()) :: binary()
   def path(ifname, opts) do
     Path.join(Keyword.fetch!(opts, :tmpdir), "chatscript.#{ifname}")
+  end
+
+  defp pdp_contexts(service_providers) do
+    {pdp_context_str, _} =
+      Enum.reduce(service_providers, {"", 1}, fn provider, {pdp_context_str, pdp_id} ->
+        %{apn: apn} = provider
+
+        pdp_context_str =
+          pdp_context_str <>
+            """
+            OK AT+CGDCONT=#{pdp_id},"IP","#{apn}"
+            """
+
+        {pdp_context_str, pdp_id + 1}
+      end)
+
+    pdp_context_str
   end
 end

--- a/lib/vintage_net_mobile/modems/quectel_BG96.ex
+++ b/lib/vintage_net_mobile/modems/quectel_BG96.ex
@@ -45,9 +45,8 @@ defmodule VintageNetMobile.Modems.QuectelBG96 do
   @impl true
   def add_raw_config(raw_config, config, opts) do
     ifname = raw_config.ifname
-    [%{apn: apn} | _] = config.service_providers
 
-    files = [{Chatscript.path(ifname, opts), Chatscript.default(apn)}]
+    files = [{Chatscript.path(ifname, opts), Chatscript.default(config.service_providers)}]
 
     up_cmds = [
       {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}

--- a/lib/vintage_net_mobile/modems/quectel_EC25AF.ex
+++ b/lib/vintage_net_mobile/modems/quectel_EC25AF.ex
@@ -12,9 +12,8 @@ defmodule VintageNetMobile.Modems.QuectelEC25AF do
   @impl true
   def add_raw_config(raw_config, config, opts) do
     ifname = raw_config.ifname
-    [%{apn: apn} | _] = config.service_providers
 
-    files = [{Chatscript.path(ifname, opts), Chatscript.default(apn)}]
+    files = [{Chatscript.path(ifname, opts), Chatscript.default(config.service_providers)}]
 
     up_cmds = [
       {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}

--- a/test/vintage_net_mobile/chatscript_test.exs
+++ b/test/vintage_net_mobile/chatscript_test.exs
@@ -33,6 +33,6 @@ defmodule VintageNetMobile.ChatscriptTest do
     CONNECT ''
     """
 
-    assert expected_chatscript == Chatscript.default("fake.apn.com")
+    assert expected_chatscript == Chatscript.default([%{apn: "fake.apn.com"}])
   end
 end

--- a/test/vintage_net_mobile/modems/quectel_BG96_test.exs
+++ b/test/vintage_net_mobile/modems/quectel_BG96_test.exs
@@ -14,7 +14,7 @@ defmodule VintageNetMobile.Modems.QuectelBG96Test do
     input = %{
       type: VintageNetMobile,
       modem: "Quectel BG96",
-      service_providers: [%{apn: "wireless.twilio.com"}]
+      service_providers: [%{apn: "superfastlte"}, %{apn: "wireless.twilio.com"}]
     }
 
     output = %RawConfig{
@@ -46,7 +46,8 @@ defmodule VintageNetMobile.Modems.QuectelBG96Test do
 
          OK ATQ0
 
-         OK AT+CGDCONT=1,"IP","wireless.twilio.com"
+         OK AT+CGDCONT=1,"IP","superfastlte"
+         OK AT+CGDCONT=2,"IP","wireless.twilio.com"
 
          OK ATDT*99***1#
 

--- a/test/vintage_net_mobile/modems/quectel_EC25AF_test.exs
+++ b/test/vintage_net_mobile/modems/quectel_EC25AF_test.exs
@@ -14,7 +14,7 @@ defmodule VintageNetMobile.Modems.QuectelEC25AFTest do
     input = %{
       type: VintageNetMobile,
       modem: "Quectel EC25-AF",
-      service_providers: [%{apn: "wireless.twilio.com"}]
+      service_providers: [%{apn: "choosethislteitissafe"}, %{apn: "wireless.twilio.com"}]
     }
 
     output = %RawConfig{
@@ -46,7 +46,8 @@ defmodule VintageNetMobile.Modems.QuectelEC25AFTest do
 
          OK ATQ0
 
-         OK AT+CGDCONT=1,"IP","wireless.twilio.com"
+         OK AT+CGDCONT=1,"IP","choosethislteitissafe"
+         OK AT+CGDCONT=2,"IP","wireless.twilio.com"
 
          OK ATDT*99***1#
 


### PR DESCRIPTION
I tested with Twilio super sims and their base sim cards on both the BG96 and EC25-AF. 

The PDP context id is generated as we iterate through the list, but I wonder if we wanted to add that field the service provider info map? The reason for this field is that some AT commands allow you to work with a particular PDP context, so this is the way to identify which context you are trying to use in those AT commands.