### PR TITLE
Minor renaming and documentation cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,16 @@
 [![CircleCI](https://circleci.com/gh/nerves-networking/vintage_net_mobile.svg?style=svg)](https://circleci.com/gh/nerves-networking/vintage_net_mobile)
 [![Coverage Status](https://coveralls.io/repos/github/nerves-networking/vintage_net_mobile/badge.svg?branch=master)](https://coveralls.io/github/nerves-networking/vintage_net_mobile?branch=master)
 
-A `VintageNet` technology for using mobile connections.
+This library provides a `VintageNet` technology for using cellular modems.
+Currently, it supports the following modules:
+
+* [`"Quectel BG96"`](https://www.quectel.com/product/bg96.htm)
+* [`"Quectel EC25"`](https://www.quectel.com/product/ec25.htm)
+* [`"ublox Toby-L2"`](https://www.u-blox.com/en/product/toby-l2-series)
+
+See the "Custom Modems" section for adding new modules.
+
+To use this library, first add it to your project's dependency list:
 
 ```elixir
 def deps do
@@ -15,43 +24,56 @@ def deps do
 end
 ```
 
-To get this technology running with VintageNet run the following:
+You will then need to configure `VintageNet`. All cellular modems currently show
+up on "ppp0", so configurations look like this:
 
 ```elixir
-    VintageNet.configure(
-      "ppp0",
-      %{
-        type: VintageNetMobile,
-        modem: your_modem,
-        service_providers: your_service_providers
-      }
-    )
+VintageNet.configure(
+  "ppp0",
+  %{
+    type: VintageNetMobile,
+    modem: your_modem,
+    service_providers: your_service_providers
+  }
+)
 ```
 
-or add this to your `config.exs`:
+The `:modem` key should be set to your modem implementation. Cellular modems
+tend to be very similar. If `vintage_net_mobile` doesn't list your modem, see
+the customizing section. It may just be a copy/paste away.
+
+The `:service_providers` key should be set to information provided by each of
+your service providers. It is common that this is a list of one item.
+Circumstances may require you to list more than one, though. Additionally, modem
+implementations may require more or less information depending on their
+implementation. (It's possible to hard-code the service provider in the modem
+implementation. In that case, this key isn't used and should be set to an empty
+list. This is useful when your cellular modem provides instructions that
+magically work and the AT commands that they give are confusing.)
+
+Information for each service provider is a map with some or all of the following
+fields:
+
+* `:apn`
+* `:type`
+
+Your service provider should provide you with the information that you need to
+connect. Often it is just an APN. The Gnome project provides a database of
+[service provider
+information](https://wiki.gnome.org/Projects/NetworkManager/MobileBroadband/ServiceProviders)
+that may also be useful.
+
+Here's an example with a service provider list:
 
 ```elixir
-config :vintage_net,
-  config: [
-    {"ppp0", %{type: VintageNetMobile, modem: your_modem, service_providers: your_service_providers}}
-  ]
+  %{
+    type: VintageNetMobile,
+    modem: your_modem,
+    service_providers: [
+      %{apn: "wireless.twilio.com"}
+    ]
+  }
 ```
-
-Service providers are maps that have an `:apn` field:
-
-```elixir
-config :vintage_net,
-  config: [
-    {"ppp0", %{type: VintageNetMobile, modem: your_modem, service_providers: [
-      %{apn: "pimentocheese"}
-    ]}}
-  ]
-```
-
-Supported modems:
-
-* `"Quectel BG96"`
-* `"Quectel EC25-AF"`
 
 ## System requirements
 
@@ -154,4 +176,3 @@ OK
 | at+cgreg? | Same as above for some modems                    |
 
 `VintageNetMobile` makes it easy to add cellular support to your device.
-

--- a/lib/vintage_net_mobile/at_parser.ex
+++ b/lib/vintage_net_mobile/at_parser.ex
@@ -1,7 +1,5 @@
 defmodule VintageNetMobile.ATParser do
-  @moduledoc """
-  Parse AT response
-  """
+  @moduledoc false
 
   @doc """
   Parse the at response

--- a/lib/vintage_net_mobile/at_runner.ex
+++ b/lib/vintage_net_mobile/at_runner.ex
@@ -1,7 +1,5 @@
 defmodule VintageNetMobile.ATRunner do
-  @moduledoc """
-  Send AT command_list to modem
-  """
+  @moduledoc false
 
   alias VintageNetMobile.ATRunner.CommandList
   alias VintageNetMobile.ATRunner.CommandList.Command

--- a/lib/vintage_net_mobile/at_runner/command_list.ex
+++ b/lib/vintage_net_mobile/at_runner/command_list.ex
@@ -1,15 +1,8 @@
 defmodule VintageNetMobile.ATRunner.CommandList do
-  @moduledoc """
-  Functions for working with commands to send to a modem
-
-  This data structure provides queueing of commands while a command is
-  currently in process.
-  """
+  @moduledoc false
 
   defmodule Command do
-    @moduledoc """
-    A command that is to be sent and handled in the `VintageNetMobile.ATRunner`
-    """
+    @moduledoc false
 
     @type t :: %__MODULE__{
             command: binary(),

--- a/lib/vintage_net_mobile/chatscript.ex
+++ b/lib/vintage_net_mobile/chatscript.ex
@@ -1,7 +1,5 @@
 defmodule VintageNetMobile.Chatscript do
-  @moduledoc """
-  Functions for working with chatscripts
-  """
+  @moduledoc false
 
   @doc """
   Output a basic default chatscript.

--- a/lib/vintage_net_mobile/modem/quectel_BG96.ex
+++ b/lib/vintage_net_mobile/modem/quectel_BG96.ex
@@ -1,12 +1,58 @@
-defmodule VintageNetMobile.Modems.QuectelEC25AF do
+defmodule VintageNetMobile.Modem.QuectelBG96 do
   @behaviour VintageNetMobile.Modem
 
-  alias VintageNetMobile.{ATRunner, SignalMonitor, PPPDConfig, Chatscript}
+  @moduledoc """
+  Quectel BG96 support
+
+  The Quectel BG96 is an LTE Cat M1/Cat NB1/EGPRS module. Here's an example
+  configuration:
+
+  ```elixir
+  {"ppp0",
+   %{
+     type: VintageNetMobile,
+     modem: "Quectel BG96",
+     service_providers: [%{apn: "super"}]
+   }}
+  ```
+  """
+
+  # To force LTE only:
+  # ```
+  # at+qcfg="nwscanmode",3,1
+  # ```
+  #
+  # To read which Radio Access Technology (RAT) is currently set:
+  #
+  # ```
+  # at+qcfg="nwscanmode"
+  # ```
+  #
+  # To disable Cat NB1 (should do this if in US):
+  #
+  # ```
+  # at+qcfg="iotopmode",0,1
+  # ```
+  #
+  # To enable Cat NB1:
+  #
+  # ```
+  # at+qcfg="iotopmode",1,1
+  # ```
+  #
+  # To enable trying both Cat NB1 and Cat M1:
+  #
+  # ```
+  # at+qcfg="iotopmode",2,1
+  # ```
+
   alias VintageNet.Interface.RawConfig
+  alias VintageNetMobile.{ATRunner, SignalMonitor, PPPDConfig, Chatscript}
 
   @impl true
   def specs() do
-    [{"Quectel EC25-AF", :_}]
+    # Support all service providers
+    [{"Quectel BG96", :_}]
   end
 
   @impl true
@@ -39,7 +85,7 @@ defmodule VintageNetMobile.Modems.QuectelEC25AF do
     if File.exists?("/dev/ttyUSB3") do
       :ok
     else
-      {:error, :missing_usb_modem}
+      {:error, :missing_modem}
     end
   end
 

--- a/lib/vintage_net_mobile/modem/quectel_EC25.ex
+++ b/lib/vintage_net_mobile/modem/quectel_EC25.ex
@@ -1,45 +1,28 @@
-defmodule VintageNetMobile.Modems.QuectelBG96 do
+defmodule VintageNetMobile.Modem.QuectelEC25 do
+  @behaviour VintageNetMobile.Modem
+
   @moduledoc """
-  To force LTE only:
+  Quectel EC25 support
 
-  ```
-  at+qcfg="nwscanmode",3,1
-  ```
+  The Quectel EC25 is a series of LTE Cat 4 modules. Here's an example
+  configuration:
 
-  To read which Radio Access Technology (RAT) is currently set:
-
-  ```
-  at+qcfg="nwscanmode"
-  ```
-
-  To disable Cat NB1 (should do this if in US):
-
-  ```
-  at+qcfg="iotopmode",0,1
-  ```
-
-  To enable Cat NB1:
-
-  ```
-  at+qcfg="iotopmode",1,1
-  ```
-
-  To enable trying both Cat NB1 and Cat M1:
-
-  ```
-  at+qcfg="iotopmode",2,1
+  ```elixir
+  {"ppp0",
+   %{
+     type: VintageNetMobile,
+     modem: "Quectel EC25",
+     service_providers: [%{apn: "super"}, %{apn: "wireless.twilio.com"}]
+   }}
   ```
   """
 
-  @behaviour VintageNetMobile.Modem
-
-  alias VintageNet.Interface.RawConfig
   alias VintageNetMobile.{ATRunner, SignalMonitor, PPPDConfig, Chatscript}
+  alias VintageNet.Interface.RawConfig
 
   @impl true
   def specs() do
-    # Support all service providers
-    [{"Quectel BG96", :_}]
+    [{"Quectel EC25", :_}]
   end
 
   @impl true
@@ -72,7 +55,7 @@ defmodule VintageNetMobile.Modems.QuectelBG96 do
     if File.exists?("/dev/ttyUSB3") do
       :ok
     else
-      {:error, :missing_modem}
+      {:error, :missing_usb_modem}
     end
   end
 

--- a/lib/vintage_net_mobile/modem/ublox_TOBYL2.ex
+++ b/lib/vintage_net_mobile/modem/ublox_TOBYL2.ex
@@ -1,5 +1,24 @@
-defmodule VintageNetMobile.Modems.UbloxTOBYL2 do
+defmodule VintageNetMobile.Modem.UbloxTOBYL2 do
   @behaviour VintageNetMobile.Modem
+
+  @moduledoc """
+  ublox TOBY-L2 support
+
+  The ublox TOBY-L2 is a series of LTE Cat 4 modules with HSPA+ and/or 2G
+  fallback. Here's an example configuration:
+
+  ```elixir
+  {"ppp0",
+   %{
+     type: VintageNetMobile,
+     modem: "u-blox TOBY-L2",
+     service_providers: [
+       %{type: "4g", apn: "lte-apn"},
+       %{type: "3g", apn: "old-apn"}
+     ]
+   }}
+  ```
+  """
 
   alias VintageNetMobile.{ATRunner, SignalMonitor, PPPDConfig, Chatscript}
   alias VintageNet.Interface.RawConfig

--- a/lib/vintage_net_mobile/modems.ex
+++ b/lib/vintage_net_mobile/modems.ex
@@ -15,9 +15,9 @@ defmodule VintageNetMobile.Modems do
   """
 
   @default_modems [
-    VintageNetMobile.Modems.QuectelBG96,
-    VintageNetMobile.Modems.QuectelEC25AF,
-    VintageNetMobile.Modems.UbloxTOBYL2
+    VintageNetMobile.Modem.QuectelBG96,
+    VintageNetMobile.Modem.QuectelEC25,
+    VintageNetMobile.Modem.UbloxTOBYL2
   ]
 
   @doc """

--- a/lib/vintage_net_mobile/pppd_config.ex
+++ b/lib/vintage_net_mobile/pppd_config.ex
@@ -1,7 +1,5 @@
 defmodule VintageNetMobile.PPPDConfig do
-  @moduledoc """
-  Module for configuring PPPD
-  """
+  @moduledoc false
 
   alias VintageNetMobile.Chatscript
   alias VintageNet.Interface.RawConfig

--- a/lib/vintage_net_mobile/pppd_notifications.ex
+++ b/lib/vintage_net_mobile/pppd_notifications.ex
@@ -1,6 +1,8 @@
 defmodule VintageNetMobile.PPPDNotifications do
   @behaviour VintageNetMobile.ToElixir.PPPDHandler
 
+  @moduledoc false
+
   alias VintageNet.{NameResolver, PropertyTable, RouteManager}
 
   require Logger

--- a/lib/vintage_net_mobile/signal_monitor.ex
+++ b/lib/vintage_net_mobile/signal_monitor.ex
@@ -1,7 +1,5 @@
 defmodule VintageNetMobile.SignalMonitor do
-  @moduledoc """
-  Monitor the signal quality of the modem
-  """
+  @moduledoc false
 
   @typedoc """
   The options for the monitor are:

--- a/test/vintage_net_mobile/modem/quectel_BG96_test.exs
+++ b/test/vintage_net_mobile/modem/quectel_BG96_test.exs
@@ -1,7 +1,7 @@
-defmodule VintageNetMobile.Modems.QuectelBG96Test do
+defmodule VintageNetMobile.Modem.QuectelBG96Test do
   use ExUnit.Case
 
-  alias VintageNetMobile.Modems.QuectelBG96
+  alias VintageNetMobile.Modem.QuectelBG96
   alias VintageNet.Interface.RawConfig
 
   test "returns table entries" do

--- a/test/vintage_net_mobile/modem/quectel_EC25_test.exs
+++ b/test/vintage_net_mobile/modem/quectel_EC25_test.exs
@@ -1,11 +1,11 @@
-defmodule VintageNetMobile.Modems.QuectelEC25AFTest do
+defmodule VintageNetMobile.Modem.QuectelEC25Test do
   use ExUnit.Case
 
-  alias VintageNetMobile.Modems.QuectelEC25AF
+  alias VintageNetMobile.Modem.QuectelEC25
   alias VintageNet.Interface.RawConfig
 
   test "returns table entries" do
-    assert [{"Quectel EC25-AF", :_}] == QuectelEC25AF.specs()
+    assert [{"Quectel EC25", :_}] == QuectelEC25.specs()
   end
 
   test "create an LTE configuration" do
@@ -13,7 +13,7 @@ defmodule VintageNetMobile.Modems.QuectelEC25AFTest do
 
     input = %{
       type: VintageNetMobile,
-      modem: "Quectel EC25-AF",
+      modem: "Quectel EC25",
       service_providers: [%{apn: "choosethislteitissafe"}, %{apn: "wireless.twilio.com"}]
     }
 
@@ -23,7 +23,7 @@ defmodule VintageNetMobile.Modems.QuectelEC25AFTest do
       source_config: input,
       require_interface: false,
       up_cmds: [
-        {:fun, QuectelEC25AF, :ready, []},
+        {:fun, QuectelEC25, :ready, []},
         {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
       ],
       files: [
@@ -81,10 +81,10 @@ defmodule VintageNetMobile.Modems.QuectelEC25AFTest do
   end
 
   test "don't allow empty providers list" do
-    assert {:error, :empty} == QuectelEC25AF.validate_service_providers([])
+    assert {:error, :empty} == QuectelEC25.validate_service_providers([])
   end
 
   test "allow for one or more service providers" do
-    assert :ok == QuectelEC25AF.validate_service_providers([1, 2])
+    assert :ok == QuectelEC25.validate_service_providers([1, 2])
   end
 end

--- a/test/vintage_net_mobile/modems_test.exs
+++ b/test/vintage_net_mobile/modems_test.exs
@@ -4,7 +4,7 @@ defmodule VintageNetMobile.ModemsTest do
   alias VintageNetMobile.Modems
 
   test "Get modem specs for Quectel BG96 with service providers" do
-    assert VintageNetMobile.Modems.QuectelBG96 ==
+    assert VintageNetMobile.Modem.QuectelBG96 ==
              Modems.lookup("Quectel BG96", [%{apn: "wireless.twilio.com"}])
   end
 


### PR DESCRIPTION
The modem implementations were renamed so that they'd appear under
the "Modem" scope since they were "Modem" behaviour implementations.
Also, the EC25-AF was renamed to EC25 since the AF part is a varient
specific to North America whereas the code should work on all EC25
variants.