### PR TITLE
Modem options

### DIFF
--- a/lib/vintage_net_mobile.ex
+++ b/lib/vintage_net_mobile.ex
@@ -15,6 +15,7 @@ defmodule VintageNetMobile do
     %{
       type: VintageNetMobile,
       modem: your_modem,
+      modem_opts: %{},
       service_providers: your_service_providers
     }
   )
@@ -22,7 +23,8 @@ defmodule VintageNetMobile do
 
   The `:modem` key should be set to your modem implementation. Cellular modems
   tend to be very similar. If `vintage_net_mobile` doesn't list your modem, see
-  the customizing section. It may just be a copy/paste away.
+  the customizing section. It may just be a copy/paste away. See your module for
+  your modem for what options can be passed to `:modem_opts`.
 
   The `:service_providers` key should be set to information provided by each of
   your service providers. It is common that this is a list of one item.

--- a/lib/vintage_net_mobile/chatscript.ex
+++ b/lib/vintage_net_mobile/chatscript.ex
@@ -47,6 +47,16 @@ defmodule VintageNetMobile.Chatscript do
   end
 
   @doc """
+  Set a PDP context to the specified provider
+  """
+  @spec set_pdp_context(non_neg_integer(), VintageNetMobile.service_provider_info()) :: String.t()
+  def set_pdp_context(id, service_provider) do
+    """
+    OK AT+CGDCONT=#{id},"IP","#{service_provider.apn}"
+    """
+  end
+
+  @doc """
   Output a basic default chatscript which connects to the first provider
 
   This is useful if all you need is a basic chatscript. If you have more
@@ -70,11 +80,5 @@ defmodule VintageNetMobile.Chatscript do
   @spec path(String.t(), keyword()) :: String.t()
   def path(ifname, opts) do
     Path.join(Keyword.fetch!(opts, :tmpdir), "chatscript.#{ifname}")
-  end
-
-  defp set_pdp_context(id, service_provider) do
-    """
-    OK AT+CGDCONT=#{id},"IP","#{service_provider.apn}"
-    """
   end
 end

--- a/lib/vintage_net_mobile/modem.ex
+++ b/lib/vintage_net_mobile/modem.ex
@@ -6,9 +6,28 @@ defmodule VintageNetMobile.Modem do
   alias VintageNet.Interface.RawConfig
 
   @doc """
-  Update the raw configuration for the modem
+  Normalize a modem configuration
+
+  Modem implementations use this to update the `:modem_opts` key to a canonical
+  representation. This could be adding default fields, migrating old options,
+  or deriving parameters to that they need not be computed again.
+
+  Configuration errors raise exceptions.
   """
-  @callback add_raw_config(RawConfig.t(), map(), keyword()) :: RawConfig.t()
+  @callback normalize(config :: map()) :: map()
+
+  @doc """
+  Update the raw configuration for the modem
+
+  The incoming raw configuration (first parameter) will have an initial generic
+  configuration that should be common to most modems. The second parameter is
+  the normalized VintageNet configuration and the final options are the ones
+  from VintageNet for determining file paths, etc.
+
+  Configuration errors raise exceptions, but it is good practice to catch the
+  errors in `normalize/1`.
+  """
+  @callback add_raw_config(RawConfig.t(), config :: map(), opts :: keyword()) :: RawConfig.t()
 
   @doc """
   Check to make sure the modem is ready to be used

--- a/lib/vintage_net_mobile/modem/quectel_BG96.ex
+++ b/lib/vintage_net_mobile/modem/quectel_BG96.ex
@@ -13,6 +13,7 @@ defmodule VintageNetMobile.Modem.QuectelBG96 do
     %{
       type: VintageNetMobile,
       modem: VintageNetMobile.Modem.QuectelBG96,
+      modem_opts: %{},
       service_providers: [%{apn: "super"}]
     }
   )
@@ -20,6 +21,14 @@ defmodule VintageNetMobile.Modem.QuectelBG96 do
 
   If multiple service providers are configured, this implementation only
   attempts to connect to the first one.
+
+  The `:modem_opts` key is optional and the following device-specific options
+  are supported:
+
+  * `:scan` - Set this to the order that radio access technologies should be
+    attempted when trying to connect. For example, `[:lte_cat_m1, :gsm]`
+    would prevent the modem from trying LTE Cat NB1 and potentially save some
+    time if you're guaranteed to not have Cat NB1 service.
 
   ## Required Linux kernel options
 
@@ -30,49 +39,54 @@ defmodule VintageNetMobile.Modem.QuectelBG96 do
   * CONFIG_USB_NET_QMI_WWAN=m
   """
 
-  # To force LTE only:
-  # ```
-  # at+qcfg="nwscanmode",3,1
-  # ```
-  #
-  # To read which Radio Access Technology (RAT) is currently set:
-  #
-  # ```
-  # at+qcfg="nwscanmode"
-  # ```
-  #
-  # To disable Cat NB1 (should do this if in US):
-  #
-  # ```
-  # at+qcfg="iotopmode",0,1
-  # ```
-  #
-  # To enable Cat NB1:
-  #
-  # ```
-  # at+qcfg="iotopmode",1,1
-  # ```
-  #
-  # To enable trying both Cat NB1 and Cat M1:
-  #
-  # ```
-  # at+qcfg="iotopmode",2,1
-  # ```
+  @typedoc """
+  Radio Access Technology (RAT)
+
+  These define how to connect to the cellular network.
+  """
+  @type rat :: :gsm | :td_scdma | :wcdma | :lte | :cdma | :lte_cat_nb1 | :lte_cat_m1
 
   alias VintageNet.Interface.RawConfig
   alias VintageNetMobile.{ATRunner, SignalMonitor, PPPDConfig, Chatscript}
 
   @impl true
   def normalize(config) do
-    modem_opts = Map.get(config, :modem_opts, %{})
+    modem_opts =
+      Map.get(config, :modem_opts, %{})
+      |> normalize_modem_opts()
+
     %{config | modem_opts: modem_opts}
+  end
+
+  defp normalize_modem_opts(modem_opts) do
+    scan = normalize_scan(Map.get(modem_opts, :scan))
+    %{scan: scan}
+  end
+
+  defp normalize_scan(nil), do: nil
+
+  defp normalize_scan(rat_list) when is_list(rat_list) do
+    supported_list = [:lte_cat_m1, :lte_cat_nb, :gsm]
+    ok_rat_list = Enum.filter(rat_list, fn rat -> rat in supported_list end)
+
+    if ok_rat_list == [] do
+      raise ArgumentError,
+            "Check your `:scan` list for technologies supported by the BG96: #{
+              inspect(supported_list)
+            } "
+    end
+
+    ok_rat_list
   end
 
   @impl true
   def add_raw_config(raw_config, config, opts) do
     ifname = raw_config.ifname
 
-    files = [{Chatscript.path(ifname, opts), Chatscript.default(config.service_providers)}]
+    files = [
+      {Chatscript.path(ifname, opts),
+       chatscript(config.service_providers, Map.get(config, :modem_opts))}
+    ]
 
     child_specs = [
       {ATRunner, [tty: "ttyUSB2", speed: 9600]},
@@ -100,4 +114,39 @@ defmodule VintageNetMobile.Modem.QuectelBG96 do
   @impl true
   def validate_service_providers([]), do: {:error, :empty}
   def validate_service_providers(_), do: :ok
+
+  defp chatscript(service_providers, modem_opts) do
+    pdp_index = 1
+
+    [
+      Chatscript.prologue(),
+      Chatscript.set_pdp_context(pdp_index, hd(service_providers)),
+      script_additions(modem_opts),
+      Chatscript.connect(pdp_index)
+    ]
+    |> IO.iodata_to_binary()
+  end
+
+  defp script_additions(nil), do: []
+
+  defp script_additions(modem_opts) when is_map(modem_opts) do
+    [
+      scan_additions(Map.get(modem_opts, :scan))
+    ]
+  end
+
+  defp scan_additions(scan_list) do
+    # This sets the sequence as specified and resets nwscanmode and iotop to be permissive
+    [
+      "OK AT+QCFG=\"nwscanseq\",",
+      Enum.map(scan_list, &scan_to_num/1),
+      "\n",
+      "OK AT+QCFG=\"nwscanmode\",0\n",
+      "OK AT+QCFG=\"iotopmode\",2\n"
+    ]
+  end
+
+  defp scan_to_num(:gsm), do: "01"
+  defp scan_to_num(:lte_cat_m1), do: "02"
+  defp scan_to_num(:lte_cat_nb1), do: "03"
 end

--- a/lib/vintage_net_mobile/modem/quectel_BG96.ex
+++ b/lib/vintage_net_mobile/modem/quectel_BG96.ex
@@ -63,6 +63,12 @@ defmodule VintageNetMobile.Modem.QuectelBG96 do
   alias VintageNetMobile.{ATRunner, SignalMonitor, PPPDConfig, Chatscript}
 
   @impl true
+  def normalize(config) do
+    modem_opts = Map.get(config, :modem_opts, %{})
+    %{config | modem_opts: modem_opts}
+  end
+
+  @impl true
   def add_raw_config(raw_config, config, opts) do
     ifname = raw_config.ifname
 

--- a/lib/vintage_net_mobile/modem/quectel_EC25.ex
+++ b/lib/vintage_net_mobile/modem/quectel_EC25.ex
@@ -34,6 +34,9 @@ defmodule VintageNetMobile.Modem.QuectelEC25 do
   alias VintageNet.Interface.RawConfig
 
   @impl true
+  def normalize(config), do: config
+
+  @impl true
   def add_raw_config(raw_config, config, opts) do
     ifname = raw_config.ifname
 

--- a/lib/vintage_net_mobile/modem/sierra_HL8548.ex
+++ b/lib/vintage_net_mobile/modem/sierra_HL8548.ex
@@ -7,17 +7,18 @@ defmodule VintageNetMobile.Modem.SierraHL8548 do
   The Sierra Wireless HL8548 is an industrial grade Embedded Wireless Module
   that provides voice and data connectivity on GPRS, EDGE, WCDMA, HSDPA and
   HSUPA networks.
+
   Here's an example configuration:
 
   ```elixir
-  {"ppp0",
-   %{
-     type: VintageNetMobile,
-     modem: VintageNetMobile.Modem.SierraHL8548,
-     service_providers: [
-       %{apn: "BROADBAND"}
-     ]
-   }}
+  VintageNet.configure(
+    "ppp0",
+    %{
+      type: VintageNetMobile,
+      modem: VintageNetMobile.Modem.SierraHL8548,
+      service_providers: [%{apn: "BROADBAND"}]
+    }
+  )
   ```
   """
 
@@ -28,8 +29,6 @@ defmodule VintageNetMobile.Modem.SierraHL8548 do
 
   alias VintageNetMobile.{ATRunner, SignalMonitor, PPPDConfig, Chatscript}
   alias VintageNet.Interface.RawConfig
-
-  require Logger
 
   @impl true
   def add_raw_config(raw_config, config, opts) do

--- a/lib/vintage_net_mobile/modem/sierra_HL8548.ex
+++ b/lib/vintage_net_mobile/modem/sierra_HL8548.ex
@@ -31,6 +31,9 @@ defmodule VintageNetMobile.Modem.SierraHL8548 do
   alias VintageNet.Interface.RawConfig
 
   @impl true
+  def normalize(config), do: config
+
+  @impl true
   def add_raw_config(raw_config, config, opts) do
     ifname = raw_config.ifname
 

--- a/lib/vintage_net_mobile/modem/ublox_TOBY_L2.ex
+++ b/lib/vintage_net_mobile/modem/ublox_TOBY_L2.ex
@@ -37,8 +37,6 @@ defmodule VintageNetMobile.Modem.UbloxTOBYL2 do
   alias VintageNetMobile.{ATRunner, SignalMonitor, PPPDConfig, Chatscript}
   alias VintageNet.Interface.RawConfig
 
-  require Logger
-
   @impl true
   def add_raw_config(raw_config, config, opts) do
     ifname = raw_config.ifname

--- a/lib/vintage_net_mobile/modem/ublox_TOBY_L2.ex
+++ b/lib/vintage_net_mobile/modem/ublox_TOBY_L2.ex
@@ -38,6 +38,9 @@ defmodule VintageNetMobile.Modem.UbloxTOBYL2 do
   alias VintageNet.Interface.RawConfig
 
   @impl true
+  def normalize(config), do: config
+
+  @impl true
   def add_raw_config(raw_config, config, opts) do
     ifname = raw_config.ifname
 

--- a/test/support/custom_modem.ex
+++ b/test/support/custom_modem.ex
@@ -4,6 +4,14 @@ defmodule VintageNetMobileTest.CustomModem do
   alias VintageNet.Interface.RawConfig
 
   @impl true
+  def normalize(config) do
+    case Map.get(config, :modem_opts, %{}) do
+      %{complain: true} -> raise ArgumentError, "CustomModem is not happy!"
+      _ -> config
+    end
+  end
+
+  @impl true
   def add_raw_config(raw_config, config, _opts) do
     ifname = raw_config.ifname
 

--- a/test/vintage_net_mobile/modem/quectel_BG96_test.exs
+++ b/test/vintage_net_mobile/modem/quectel_BG96_test.exs
@@ -10,7 +10,7 @@ defmodule VintageNetMobile.Modem.QuectelBG96Test do
     input = %{
       type: VintageNetMobile,
       modem: QuectelBG96,
-      service_providers: [%{apn: "superfastlte"}, %{apn: "wireless.twilio.com"}]
+      service_providers: [%{apn: "m1_service"}]
     }
 
     output = %RawConfig{
@@ -42,7 +42,7 @@ defmodule VintageNetMobile.Modem.QuectelBG96Test do
          OK ATH
          OK ATZ
          OK ATQ0
-         OK AT+CGDCONT=1,"IP","superfastlte"
+         OK AT+CGDCONT=1,"IP","m1_service"
          OK ATDT*99***1#
          CONNECT ''
          """}
@@ -71,6 +71,108 @@ defmodule VintageNetMobile.Modem.QuectelBG96Test do
     }
 
     assert output == VintageNetMobile.to_raw_config("ppp0", input, Utils.default_opts())
+  end
+
+  test "restrict to LTE Cat M1-only" do
+    priv_dir = Application.app_dir(:vintage_net_mobile, "priv")
+
+    input = %{
+      type: VintageNetMobile,
+      modem: QuectelBG96,
+      modem_opts: %{scan: [:lte_cat_m1]},
+      service_providers: [%{apn: "m1_service"}]
+    }
+
+    output = %RawConfig{
+      ifname: "ppp0",
+      type: VintageNetMobile,
+      source_config: input,
+      require_interface: false,
+      up_cmds: [
+        {:fun, QuectelBG96, :ready, []},
+        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
+      ],
+      down_cmds: [
+        {:fun, VintageNet.PropertyTable, :clear_prefix,
+         [VintageNet, ["interface", "ppp0", "mobile"]]}
+      ],
+      files: [
+        {"/tmp/vintage_net/chatscript.ppp0",
+         """
+         ABORT 'BUSY'
+         ABORT 'NO CARRIER'
+         ABORT 'NO DIALTONE'
+         ABORT 'NO DIAL TONE'
+         ABORT 'NO ANSWER'
+         ABORT 'DELAYED'
+         TIMEOUT 10
+         REPORT CONNECT
+         "" +++
+         "" AT
+         OK ATH
+         OK ATZ
+         OK ATQ0
+         OK AT+CGDCONT=1,"IP","m1_service"
+         OK AT+QCFG="nwscanseq",02
+         OK AT+QCFG="nwscanmode",0
+         OK AT+QCFG="iotopmode",2
+         OK ATDT*99***1#
+         CONNECT ''
+         """}
+      ],
+      child_specs: [
+        {MuonTrap.Daemon,
+         [
+           "pppd",
+           [
+             "connect",
+             "chat -v -f /tmp/vintage_net/chatscript.ppp0",
+             "ttyUSB3",
+             "9600",
+             "noipdefault",
+             "usepeerdns",
+             "persist",
+             "noauth",
+             "nodetach",
+             "debug"
+           ],
+           [env: [{"PRIV_DIR", priv_dir}, {"LD_PRELOAD", Path.join(priv_dir, "pppd_shim.so")}]]
+         ]},
+        {VintageNetMobile.ATRunner, [tty: "ttyUSB2", speed: 9600]},
+        {VintageNetMobile.SignalMonitor, [ifname: "ppp0", tty: "ttyUSB2"]}
+      ]
+    }
+
+    assert output == VintageNetMobile.to_raw_config("ppp0", input, Utils.default_opts())
+  end
+
+  test "normalize filters unsupported rats" do
+    input = %{
+      type: VintageNetMobile,
+      modem: QuectelBG96,
+      modem_opts: %{scan: [:lte_cat_m1, :gsm, :lte]},
+      service_providers: [%{apn: "m1_service"}]
+    }
+
+    output = %{
+      type: VintageNetMobile,
+      modem: QuectelBG96,
+      modem_opts: %{scan: [:lte_cat_m1, :gsm]},
+      service_providers: [%{apn: "m1_service"}]
+    }
+
+    assert VintageNetMobile.normalize(input) == output
+  end
+
+  test "normalize raises if no supported rats" do
+    input = %{
+      type: VintageNetMobile,
+      modem: QuectelBG96,
+      modem_opts: %{scan: [:lte]},
+      service_providers: [%{apn: "m1_service"}]
+    }
+
+    assert_raise ArgumentError, fn -> VintageNetMobile.normalize(input) end
   end
 
   test "don't allow empty providers list" do

--- a/test/vintage_net_mobile_test.exs
+++ b/test/vintage_net_mobile_test.exs
@@ -4,6 +4,16 @@ defmodule VintageNetMobileTest do
   alias VintageNet.Interface.RawConfig
   alias VintageNetMobileTest.{CustomModem, Utils}
 
+  test "normalizes configurations" do
+    input = %{
+      type: VintageNetMobile,
+      modem: VintageNetMobileTest.CustomModem,
+      service_providers: [%{apn: "free_lte"}]
+    }
+
+    assert VintageNetMobile.normalize(input) == input
+  end
+
   test "create a configuration for a custom mode" do
     input = %{
       type: VintageNetMobile,
@@ -37,6 +47,10 @@ defmodule VintageNetMobileTest do
     }
 
     assert_raise ArgumentError, fn ->
+      VintageNetMobile.normalize(input)
+    end
+
+    assert_raise ArgumentError, fn ->
       VintageNetMobile.to_raw_config("ppp0", input, Utils.default_opts())
     end
   end
@@ -47,6 +61,10 @@ defmodule VintageNetMobileTest do
       modem: VintageNetMobile.Modem.DoesNotExist,
       service_providers: [%{apn: "apn"}]
     }
+
+    assert_raise UndefinedFunctionError, fn ->
+      VintageNetMobile.normalize(input)
+    end
 
     assert_raise UndefinedFunctionError, fn ->
       VintageNetMobile.to_raw_config("ppp0", input, Utils.default_opts())


### PR DESCRIPTION
I'm adding support for passing modem-specific options. Part of this required pushing configuration normalization down to the modem implementations. If this weren't done, then the modem implementations wouldn't be able to validate or migrate options which would have been unfortunate.

This also brought up that `vintage_net_mobile` is inconsistent with the other `vintage_net_*` in that it has top-level options whereas the others put their options under their own namespaces. I'll be fixing that up in a future PR.