### PR TITLE
Move mobile parameters under vintage_net_mobile key

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,28 +29,27 @@ You will then need to configure `VintageNet`. All cellular modems currently show
 up on "ppp0", so configurations look like this:
 
 ```elixir
-VintageNet.configure(
-  "ppp0",
-  %{
-    type: VintageNetMobile,
-    modem: your_modem,
-    service_providers: your_service_providers
-  }
-)
+VintageNet.configure("ppp0", %{
+      type: VintageNetMobile,
+      vintage_net_mobile: %{
+        modem: your_modem,
+        service_providers: your_service_providers
+      }
+    })
 ```
 
 The `:modem` key should be set to your modem implementation. Cellular modems
-tend to be very similar. If `vintage_net_mobile` doesn't list your modem, see
+tend to be very similar. If `vintage_net_mobile` doesn't support your modem, see
 the customizing section. It may just be a copy/paste away.
 
 The `:service_providers` key should be set to information provided by each of
 your service providers. It is common that this is a list of one item.
 Circumstances may require you to list more than one, though. Additionally, modem
-implementations may require more or less information depending on their
-implementation. (It's possible to hard-code the service provider in the modem
-implementation. In that case, this key isn't used and should be set to an empty
-list. This is useful when your cellular modem provides instructions that
-magically work and the AT commands that they give are confusing.)
+implementations may require more information. (It's also possible to hard-code
+the service provider in the modem implementation as a hack. In that case, this
+key isn't used and should be set to an empty list. This is useful when your
+cellular modem provides instructions that magically work and the AT commands
+that they give are confusing.)
 
 Information for each service provider is a map with some or all of the following
 fields:
@@ -69,10 +68,12 @@ Here's an example with a service provider list:
 ```elixir
   %{
     type: VintageNetMobile,
-    modem: your_modem,
-    service_providers: [
-      %{apn: "wireless.twilio.com"}
-    ]
+    vintage_net_mobile: %{
+      modem: your_modem,
+      service_providers: [
+        %{apn: "wireless.twilio.com"}
+      ]
+    }
   }
 ```
 

--- a/lib/vintage_net_mobile.ex
+++ b/lib/vintage_net_mobile.ex
@@ -88,18 +88,18 @@ defmodule VintageNetMobile do
         }
 
   @impl true
-  def normalize(config) do
-    modem = Map.fetch!(config, :modem)
-    service_providers = Map.get(config, :service_providers)
-
+  def normalize(%{type: __MODULE__, vintage_net_mobile: mobile} = config) do
+    modem = Map.fetch!(mobile, :modem)
+    service_providers = Map.get(mobile, :service_providers)
     validate_service_providers!(modem, service_providers)
 
     modem.normalize(config)
   end
 
   @impl true
-  def to_raw_config(ifname, %{type: __MODULE__, modem: modem} = config, opts) do
-    service_providers = Map.get(config, :service_providers)
+  def to_raw_config(ifname, %{type: __MODULE__, vintage_net_mobile: mobile} = config, opts) do
+    modem = Map.fetch!(mobile, :modem)
+    service_providers = Map.get(mobile, :service_providers)
     validate_service_providers!(modem, service_providers)
 
     %RawConfig{

--- a/lib/vintage_net_mobile/modem/quectel_EC25.ex
+++ b/lib/vintage_net_mobile/modem/quectel_EC25.ex
@@ -12,8 +12,10 @@ defmodule VintageNetMobile.Modem.QuectelEC25 do
     "ppp0",
     %{
       type: VintageNetMobile,
-      modem: VintageNetMobile.Modem.QuectelEC25,
-      service_providers: [%{apn: "wireless.twilio.com"}]
+      vintage_net_mobile: %{
+        modem: VintageNetMobile.Modem.QuectelEC25,
+        service_providers: [%{apn: "wireless.twilio.com"}]
+      }
     }
   )
   ```
@@ -37,10 +39,10 @@ defmodule VintageNetMobile.Modem.QuectelEC25 do
   def normalize(config), do: config
 
   @impl true
-  def add_raw_config(raw_config, config, opts) do
+  def add_raw_config(raw_config, %{vintage_net_mobile: mobile} = _config, opts) do
     ifname = raw_config.ifname
 
-    files = [{Chatscript.path(ifname, opts), Chatscript.default(config.service_providers)}]
+    files = [{Chatscript.path(ifname, opts), Chatscript.default(mobile.service_providers)}]
 
     child_specs = [
       {ATRunner, [tty: "ttyUSB2", speed: 9600]},

--- a/lib/vintage_net_mobile/modem/sierra_HL8548.ex
+++ b/lib/vintage_net_mobile/modem/sierra_HL8548.ex
@@ -15,8 +15,10 @@ defmodule VintageNetMobile.Modem.SierraHL8548 do
     "ppp0",
     %{
       type: VintageNetMobile,
-      modem: VintageNetMobile.Modem.SierraHL8548,
-      service_providers: [%{apn: "BROADBAND"}]
+      vintage_net_mobile: %{
+        modem: VintageNetMobile.Modem.SierraHL8548,
+        service_providers: [%{apn: "BROADBAND"}]
+      }
     }
   )
   ```
@@ -34,10 +36,10 @@ defmodule VintageNetMobile.Modem.SierraHL8548 do
   def normalize(config), do: config
 
   @impl true
-  def add_raw_config(raw_config, config, opts) do
+  def add_raw_config(raw_config, %{vintage_net_mobile: mobile} = _config, opts) do
     ifname = raw_config.ifname
 
-    files = [{Chatscript.path(ifname, opts), Chatscript.default(config.service_providers)}]
+    files = [{Chatscript.path(ifname, opts), Chatscript.default(mobile.service_providers)}]
 
     child_specs = [
       {ATRunner, [tty: "ttyACM3", speed: 115_200]},

--- a/lib/vintage_net_mobile/modem/ublox_TOBY_L2.ex
+++ b/lib/vintage_net_mobile/modem/ublox_TOBY_L2.ex
@@ -12,11 +12,13 @@ defmodule VintageNetMobile.Modem.UbloxTOBYL2 do
     "ppp0",
     %{
       type: VintageNetMobile,
-       modem: VintageNetMobile.Modem.UbloxTOBYL2,
-       service_providers: [
-         %{apn: "lte-apn", usage: :eps_bearer},
-         %{apn: "old-apn", usage: :pdp}
-       ]
+      vintage_net_mobile: %{
+        modem: VintageNetMobile.Modem.UbloxTOBYL2,
+        service_providers: [
+          %{apn: "lte-apn", usage: :eps_bearer},
+          %{apn: "old-apn", usage: :pdp}
+        ]
+      }
     }
   )
   ```
@@ -41,10 +43,10 @@ defmodule VintageNetMobile.Modem.UbloxTOBYL2 do
   def normalize(config), do: config
 
   @impl true
-  def add_raw_config(raw_config, config, opts) do
+  def add_raw_config(raw_config, %{vintage_net_mobile: mobile} = _config, opts) do
     ifname = raw_config.ifname
 
-    files = [{Chatscript.path(ifname, opts), chatscript(config.service_providers)}]
+    files = [{Chatscript.path(ifname, opts), chatscript(mobile.service_providers)}]
 
     child_specs = [
       {ATRunner, [tty: "ttyACM1", speed: 115_200]},

--- a/test/support/custom_modem.ex
+++ b/test/support/custom_modem.ex
@@ -4,11 +4,12 @@ defmodule VintageNetMobileTest.CustomModem do
   alias VintageNet.Interface.RawConfig
 
   @impl true
-  def normalize(config) do
-    case Map.get(config, :modem_opts, %{}) do
-      %{complain: true} -> raise ArgumentError, "CustomModem is not happy!"
-      _ -> config
+  def normalize(%{vintage_net_mobile: mobile} = config) do
+    if Map.get(mobile, :complain, false) do
+      raise ArgumentError, "CustomModem is not happy!"
     end
+
+    config
   end
 
   @impl true
@@ -19,7 +20,7 @@ defmodule VintageNetMobileTest.CustomModem do
       raw_config
       | files: [
           {"chatscript.#{ifname}",
-           "The service providers are #{inspect(config.service_providers)}"}
+           "The service providers are #{inspect(config.vintage_net_mobile.service_providers)}"}
         ]
     }
   end

--- a/test/vintage_net_mobile/modem/quectel_BG96_test.exs
+++ b/test/vintage_net_mobile/modem/quectel_BG96_test.exs
@@ -9,8 +9,10 @@ defmodule VintageNetMobile.Modem.QuectelBG96Test do
 
     input = %{
       type: VintageNetMobile,
-      modem: QuectelBG96,
-      service_providers: [%{apn: "m1_service"}]
+      vintage_net_mobile: %{
+        modem: QuectelBG96,
+        service_providers: [%{apn: "m1_service"}]
+      }
     }
 
     output = %RawConfig{
@@ -78,9 +80,11 @@ defmodule VintageNetMobile.Modem.QuectelBG96Test do
 
     input = %{
       type: VintageNetMobile,
-      modem: QuectelBG96,
-      modem_opts: %{scan: [:lte_cat_m1]},
-      service_providers: [%{apn: "m1_service"}]
+      vintage_net_mobile: %{
+        modem: QuectelBG96,
+        service_providers: [%{apn: "m1_service"}],
+        scan: [:lte_cat_m1]
+      }
     }
 
     output = %RawConfig{
@@ -149,16 +153,20 @@ defmodule VintageNetMobile.Modem.QuectelBG96Test do
   test "normalize filters unsupported rats" do
     input = %{
       type: VintageNetMobile,
-      modem: QuectelBG96,
-      modem_opts: %{scan: [:lte_cat_m1, :gsm, :lte]},
-      service_providers: [%{apn: "m1_service"}]
+      vintage_net_mobile: %{
+        modem: QuectelBG96,
+        service_providers: [%{apn: "m1_service"}],
+        scan: [:lte_cat_m1, :gsm, :lte]
+      }
     }
 
     output = %{
       type: VintageNetMobile,
-      modem: QuectelBG96,
-      modem_opts: %{scan: [:lte_cat_m1, :gsm]},
-      service_providers: [%{apn: "m1_service"}]
+      vintage_net_mobile: %{
+        modem: QuectelBG96,
+        scan: [:lte_cat_m1, :gsm],
+        service_providers: [%{apn: "m1_service"}]
+      }
     }
 
     assert VintageNetMobile.normalize(input) == output
@@ -167,9 +175,11 @@ defmodule VintageNetMobile.Modem.QuectelBG96Test do
   test "normalize raises if no supported rats" do
     input = %{
       type: VintageNetMobile,
-      modem: QuectelBG96,
-      modem_opts: %{scan: [:lte]},
-      service_providers: [%{apn: "m1_service"}]
+      vintage_net_mobile: %{
+        modem: QuectelBG96,
+        scan: [:lte],
+        service_providers: [%{apn: "m1_service"}]
+      }
     }
 
     assert_raise ArgumentError, fn -> VintageNetMobile.normalize(input) end

--- a/test/vintage_net_mobile/modem/quectel_EC25_test.exs
+++ b/test/vintage_net_mobile/modem/quectel_EC25_test.exs
@@ -9,8 +9,10 @@ defmodule VintageNetMobile.Modem.QuectelEC25Test do
 
     input = %{
       type: VintageNetMobile,
-      modem: QuectelEC25,
-      service_providers: [%{apn: "choosethislteitissafe"}, %{apn: "wireless.twilio.com"}]
+      vintage_net_mobile: %{
+        modem: QuectelEC25,
+        service_providers: [%{apn: "choosethislteitissafe"}, %{apn: "wireless.twilio.com"}]
+      }
     }
 
     output = %RawConfig{

--- a/test/vintage_net_mobile/modem/sierra_HL8548_test.exs
+++ b/test/vintage_net_mobile/modem/sierra_HL8548_test.exs
@@ -9,72 +9,66 @@ defmodule VintageNetMobile.Modem.SierraHL8548Test do
 
     input = %{
       type: VintageNetMobile,
-      modem: SierraHL8548,
-      service_providers: [
-        %{apn: "choosethislteitissafe"}
-      ]
+      vintage_net_mobile: %{
+        modem: SierraHL8548,
+        service_providers: [%{apn: "choosethislteitissafe"}]
+      }
     }
 
     output = %RawConfig{
-      child_specs: [
-        "Elixir.MuonTrap.Daemon": [
-          "pppd",
-          [
-            "connect",
-            "chat -v -f /tmp/vintage_net/chatscript.ppp0",
-            "ttyACM4",
-            "115200",
-            "noipdefault",
-            "usepeerdns",
-            "persist",
-            "noauth",
-            "nodetach",
-            "debug"
-          ],
-          [env: [{"PRIV_DIR", priv_dir}, {"LD_PRELOAD", Path.join(priv_dir, "pppd_shim.so")}]]
-        ],
-        "Elixir.VintageNetMobile.ATRunner": [tty: "ttyACM3", speed: 115_200],
-        "Elixir.VintageNetMobile.SignalMonitor": [ifname: "ppp0", tty: "ttyACM3"]
-      ],
-      cleanup_files: '',
-      down_cmd_millis: 5000,
-      files: [
-        {
-          "/tmp/vintage_net/chatscript.ppp0",
-          """
-          ABORT 'BUSY'
-          ABORT 'NO CARRIER'
-          ABORT 'NO DIALTONE'
-          ABORT 'NO DIAL TONE'
-          ABORT 'NO ANSWER'
-          ABORT 'DELAYED'
-          TIMEOUT 10
-          REPORT CONNECT
-          "" +++
-          "" AT
-          OK ATH
-          OK ATZ
-          OK ATQ0
-          OK AT+CGDCONT=1,"IP","choosethislteitissafe"
-          OK ATDT*99***1#
-          CONNECT ''
-          """
-        }
-      ],
       ifname: "ppp0",
-      require_interface: false,
-      restart_strategy: :one_for_all,
-      retry_millis: 30000,
-      source_config: input,
       type: VintageNetMobile,
-      up_cmd_millis: 5000,
+      source_config: input,
+      require_interface: false,
       up_cmds: [
-        {:fun, VintageNetMobile.Modem.SierraHL8548, :ready, ''},
+        {:fun, VintageNetMobile.Modem.SierraHL8548, :ready, []},
         {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
       ],
       down_cmds: [
         {:fun, VintageNet.PropertyTable, :clear_prefix,
          [VintageNet, ["interface", "ppp0", "mobile"]]}
+      ],
+      files: [
+        {"/tmp/vintage_net/chatscript.ppp0",
+         """
+         ABORT 'BUSY'
+         ABORT 'NO CARRIER'
+         ABORT 'NO DIALTONE'
+         ABORT 'NO DIAL TONE'
+         ABORT 'NO ANSWER'
+         ABORT 'DELAYED'
+         TIMEOUT 10
+         REPORT CONNECT
+         "" +++
+         "" AT
+         OK ATH
+         OK ATZ
+         OK ATQ0
+         OK AT+CGDCONT=1,"IP","choosethislteitissafe"
+         OK ATDT*99***1#
+         CONNECT ''
+         """}
+      ],
+      child_specs: [
+        {MuonTrap.Daemon,
+         [
+           "pppd",
+           [
+             "connect",
+             "chat -v -f /tmp/vintage_net/chatscript.ppp0",
+             "ttyACM4",
+             "115200",
+             "noipdefault",
+             "usepeerdns",
+             "persist",
+             "noauth",
+             "nodetach",
+             "debug"
+           ],
+           [env: [{"PRIV_DIR", priv_dir}, {"LD_PRELOAD", Path.join(priv_dir, "pppd_shim.so")}]]
+         ]},
+        {VintageNetMobile.ATRunner, [tty: "ttyACM3", speed: 115_200]},
+        {VintageNetMobile.SignalMonitor, [ifname: "ppp0", tty: "ttyACM3"]}
       ]
     }
 

--- a/test/vintage_net_mobile_test.exs
+++ b/test/vintage_net_mobile_test.exs
@@ -7,18 +7,35 @@ defmodule VintageNetMobileTest do
   test "normalizes configurations" do
     input = %{
       type: VintageNetMobile,
-      modem: VintageNetMobileTest.CustomModem,
-      service_providers: [%{apn: "free_lte"}]
+      vintage_net_mobile: %{
+        modem: VintageNetMobileTest.CustomModem,
+        service_providers: [%{apn: "free_lte"}]
+      }
     }
 
     assert VintageNetMobile.normalize(input) == input
   end
 
+  test "raises if normalize raises" do
+    input = %{
+      type: VintageNetMobile,
+      vintage_net_mobile: %{
+        modem: VintageNetMobileTest.CustomModem,
+        service_providers: [%{apn: "free_lte"}],
+        complain: true
+      }
+    }
+
+    assert_raise ArgumentError, fn -> VintageNetMobile.normalize(input) end
+  end
+
   test "create a configuration for a custom mode" do
     input = %{
       type: VintageNetMobile,
-      modem: VintageNetMobileTest.CustomModem,
-      service_providers: [%{apn: "free_lte"}]
+      vintage_net_mobile: %{
+        modem: VintageNetMobileTest.CustomModem,
+        service_providers: [%{apn: "free_lte"}]
+      }
     }
 
     output = %RawConfig{
@@ -42,8 +59,10 @@ defmodule VintageNetMobileTest do
   test "raises when service providers list is invalid" do
     input = %{
       type: VintageNetMobile,
-      modem: VintageNetMobile.Modem.QuectelBG96,
-      service_providers: []
+      vintage_net_mobile: %{
+        modem: VintageNetMobile.Modem.QuectelBG96,
+        service_providers: []
+      }
     }
 
     assert_raise ArgumentError, fn ->
@@ -58,8 +77,10 @@ defmodule VintageNetMobileTest do
   test "raises when unknown modem" do
     input = %{
       type: VintageNetMobile,
-      modem: VintageNetMobile.Modem.DoesNotExist,
-      service_providers: [%{apn: "apn"}]
+      vintage_net_mobile: %{
+        modem: VintageNetMobile.Modem.DoesNotExist,
+        service_providers: [%{apn: "apn"}]
+      }
     }
 
     assert_raise UndefinedFunctionError, fn ->


### PR DESCRIPTION
This makes this VintageNet technology consistent with the other
technologies by having it manage its configuration under its own
namespace.

The second change that was made is that modem_opts are not under the
vintage_net_mobile namespace. It didn't seem useful any longer to have
them buried any more deeply. This only affects the BG96.

Lastly a few simplifications were made to the unit tests. They don't
change anything but it makes it easier to compare tests from different
modems to see how they differ.