### PR TITLE
Refactor service provider validation back into normalization

### DIFF
--- a/lib/vintage_net_mobile.ex
+++ b/lib/vintage_net_mobile.ex
@@ -90,8 +90,6 @@ defmodule VintageNetMobile do
   @impl true
   def normalize(%{type: __MODULE__, vintage_net_mobile: mobile} = config) do
     modem = Map.fetch!(mobile, :modem)
-    service_providers = Map.get(mobile, :service_providers)
-    validate_service_providers!(modem, service_providers)
 
     modem.normalize(config)
   end
@@ -99,8 +97,6 @@ defmodule VintageNetMobile do
   @impl true
   def to_raw_config(ifname, %{type: __MODULE__, vintage_net_mobile: mobile} = config, opts) do
     modem = Map.fetch!(mobile, :modem)
-    service_providers = Map.get(mobile, :service_providers)
-    validate_service_providers!(modem, service_providers)
 
     %RawConfig{
       ifname: ifname,
@@ -118,21 +114,6 @@ defmodule VintageNetMobile do
   # TODO: implement
   @impl true
   def check_system(_), do: :ok
-
-  defp validate_service_providers!(modem, service_providers) do
-    case modem.validate_service_providers(service_providers) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        raise ArgumentError, """
-        Looks like you provided invalid service providers because #{inspect(reason)}.
-
-        Please see your modem's documentation in regards to what it expects from
-        the configured service providers.
-        """
-    end
-  end
 
   defp add_start_commands(raw_config, modem) do
     # The modem.ready call checks whether the modem exists and can be started.

--- a/lib/vintage_net_mobile/modem.ex
+++ b/lib/vintage_net_mobile/modem.ex
@@ -33,10 +33,4 @@ defmodule VintageNetMobile.Modem do
   Check to make sure the modem is ready to be used
   """
   @callback ready() :: :ok | {:error, :missing_modem}
-
-  @doc """
-  Validate the service providers for the modem
-  """
-  @callback validate_service_providers([VintageNetMobile.service_provider_info()]) ::
-              :ok | {:error, reason :: any()}
 end

--- a/lib/vintage_net_mobile/modem/quectel_BG96.ex
+++ b/lib/vintage_net_mobile/modem/quectel_BG96.ex
@@ -49,17 +49,19 @@ defmodule VintageNetMobile.Modem.QuectelBG96 do
 
   alias VintageNet.Interface.RawConfig
   alias VintageNetMobile.{ExChat, SignalMonitor, PPPDConfig, Chatscript}
+  alias VintageNetMobile.Modem.Utils
 
   @impl true
-  def normalize(%{vintage_net_mobile: mobile} = config) do
-    new_mobile = normalize_mobile_opts(mobile)
-
-    %{config | vintage_net_mobile: new_mobile}
+  def normalize(config) do
+    config
+    |> Utils.require_a_service_provider()
+    |> normalize_mobile_opts()
   end
 
-  defp normalize_mobile_opts(mobile) do
+  defp normalize_mobile_opts(%{vintage_net_mobile: mobile} = config) do
     scan = normalize_scan(Map.get(mobile, :scan))
-    %{mobile | scan: scan}
+    new_mobile = %{mobile | scan: scan}
+    %{config | vintage_net_mobile: new_mobile}
   end
 
   defp normalize_scan(nil), do: nil
@@ -108,10 +110,6 @@ defmodule VintageNetMobile.Modem.QuectelBG96 do
       {:error, :missing_modem}
     end
   end
-
-  @impl true
-  def validate_service_providers([]), do: {:error, :empty}
-  def validate_service_providers(_), do: :ok
 
   defp chatscript(mobile) do
     pdp_index = 1

--- a/lib/vintage_net_mobile/modem/quectel_EC25.ex
+++ b/lib/vintage_net_mobile/modem/quectel_EC25.ex
@@ -24,10 +24,14 @@ defmodule VintageNetMobile.Modem.QuectelEC25 do
   """
 
   alias VintageNetMobile.{ExChat, SignalMonitor, PPPDConfig, Chatscript}
+  alias VintageNetMobile.Modem.Utils
   alias VintageNet.Interface.RawConfig
 
   @impl true
-  def normalize(config), do: config
+  def normalize(config) do
+    config
+    |> Utils.require_a_service_provider()
+  end
 
   @impl true
   def add_raw_config(raw_config, %{vintage_net_mobile: mobile} = _config, opts) do
@@ -57,8 +61,4 @@ defmodule VintageNetMobile.Modem.QuectelEC25 do
       {:error, :missing_usb_modem}
     end
   end
-
-  @impl true
-  def validate_service_providers([]), do: {:error, :empty}
-  def validate_service_providers(_), do: :ok
 end

--- a/lib/vintage_net_mobile/modem/sierra_HL8548.ex
+++ b/lib/vintage_net_mobile/modem/sierra_HL8548.ex
@@ -30,10 +30,14 @@ defmodule VintageNetMobile.Modem.SierraHL8548 do
   @behaviour VintageNetMobile.Modem
 
   alias VintageNetMobile.{ExChat, SignalMonitor, PPPDConfig, Chatscript}
+  alias VintageNetMobile.Modem.Utils
   alias VintageNet.Interface.RawConfig
 
   @impl true
-  def normalize(config), do: config
+  def normalize(config) do
+    config
+    |> Utils.require_a_service_provider()
+  end
 
   @impl true
   def add_raw_config(raw_config, %{vintage_net_mobile: mobile} = _config, opts) do
@@ -63,8 +67,4 @@ defmodule VintageNetMobile.Modem.SierraHL8548 do
       {:error, :missing_modem}
     end
   end
-
-  @impl true
-  def validate_service_providers([]), do: {:error, :empty}
-  def validate_service_providers(_), do: :ok
 end

--- a/lib/vintage_net_mobile/modem/utils.ex
+++ b/lib/vintage_net_mobile/modem/utils.ex
@@ -1,0 +1,49 @@
+defmodule VintageNetMobile.Modem.Utils do
+  @moduledoc false
+
+  # These are general utility functions for modem implementations
+
+  @doc """
+  Check that the configuration has a service provider and that the service provider has the required fields
+  """
+  @spec require_a_service_provider(config :: map(), [atom()]) :: map()
+  def require_a_service_provider(
+        %{type: VintageNetMobile, vintage_net_mobile: mobile} = config,
+        required_fields \\ [:apn]
+      ) do
+    case Map.get(mobile, :service_providers, []) do
+      [] ->
+        service_provider =
+          for field <- required_fields, into: %{} do
+            {field, to_string(field)}
+          end
+
+        new_config = %{
+          config
+          | vintage_net_mobile: Map.put(mobile, :service_providers, [service_provider])
+        }
+
+        raise ArgumentError,
+              """
+              At least one service provider is required for #{inspect(mobile.modem)}.
+
+              For example:
+
+              #{inspect(new_config)}
+              """
+
+      [service_provider | _rest] ->
+        missing =
+          Enum.find(required_fields, fn field -> not Map.has_key?(service_provider, field) end)
+
+        if missing do
+          raise ArgumentError,
+                """
+                The service provider '#{inspect(service_provider)}' is missing the `inspect(missing)' field.
+                """
+        end
+
+        config
+    end
+  end
+end

--- a/test/support/custom_modem.ex
+++ b/test/support/custom_modem.ex
@@ -27,7 +27,4 @@ defmodule VintageNetMobileTest.CustomModem do
 
   @impl true
   def ready(), do: :ok
-
-  @impl true
-  def validate_service_providers(_), do: :ok
 end

--- a/test/vintage_net_mobile/modem/quectel_BG96_test.exs
+++ b/test/vintage_net_mobile/modem/quectel_BG96_test.exs
@@ -185,11 +185,27 @@ defmodule VintageNetMobile.Modem.QuectelBG96Test do
     assert_raise ArgumentError, fn -> VintageNetMobile.normalize(input) end
   end
 
-  test "don't allow empty providers list" do
-    assert {:error, :empty} == QuectelBG96.validate_service_providers([])
+  test "requires one provider" do
+    input = %{
+      type: VintageNetMobile,
+      vintage_net_mobile: %{
+        modem: QuectelBG96,
+        service_providers: []
+      }
+    }
+
+    assert_raise ArgumentError, fn -> QuectelBG96.normalize(input) end
   end
 
-  test "allow for one or more service providers" do
-    assert :ok == QuectelBG96.validate_service_providers([1, 2])
+  test "requires provider to have an apn" do
+    input = %{
+      type: VintageNetMobile,
+      vintage_net_mobile: %{
+        modem: QuectelBG96,
+        service_providers: [%{not_apn: "asdf"}]
+      }
+    }
+
+    assert_raise ArgumentError, fn -> QuectelBG96.normalize(input) end
   end
 end

--- a/test/vintage_net_mobile/modem/quectel_EC25_test.exs
+++ b/test/vintage_net_mobile/modem/quectel_EC25_test.exs
@@ -74,12 +74,4 @@ defmodule VintageNetMobile.Modem.QuectelEC25Test do
 
     assert output == VintageNetMobile.to_raw_config("ppp0", input, Utils.default_opts())
   end
-
-  test "don't allow empty providers list" do
-    assert {:error, :empty} == QuectelEC25.validate_service_providers([])
-  end
-
-  test "allow for one or more service providers" do
-    assert :ok == QuectelEC25.validate_service_providers([1, 2])
-  end
 end

--- a/test/vintage_net_mobile/modem/ublox_TOBY_L2_test.exs
+++ b/test/vintage_net_mobile/modem/ublox_TOBY_L2_test.exs
@@ -101,7 +101,7 @@ defmodule VintageNetMobile.Modem.UbloxTOBYL2Test do
     }
 
     assert_raise ArgumentError, fn ->
-      VintageNetMobile.to_raw_config("ppp0", input, Utils.default_opts())
+      VintageNetMobile.normalize(input)
     end
   end
 end

--- a/test/vintage_net_mobile/modem/utils_test.exs
+++ b/test/vintage_net_mobile/modem/utils_test.exs
@@ -1,0 +1,48 @@
+defmodule VintageNetMobile.Modem.UtilsTest do
+  use ExUnit.Case
+
+  alias VintageNetMobile.Modem.Utils
+
+  test "requires one provider" do
+    input = %{
+      type: VintageNetMobile,
+      vintage_net_mobile: %{
+        modem: QuectelBG96,
+        service_providers: []
+      }
+    }
+
+    assert_raise ArgumentError, fn -> Utils.require_a_service_provider(input) end
+  end
+
+  test "requires provider to have an apn" do
+    input = %{
+      type: VintageNetMobile,
+      vintage_net_mobile: %{
+        modem: QuectelBG96,
+        service_providers: [%{not_apn: "asdf"}]
+      }
+    }
+
+    assert_raise ArgumentError, fn -> Utils.require_a_service_provider(input) end
+  end
+
+  test "requires provider to have multiple fields" do
+    input = %{
+      type: VintageNetMobile,
+      vintage_net_mobile: %{
+        modem: QuectelBG96,
+        service_providers: [%{apn: "asdf", another: "something"}]
+      }
+    }
+
+    Utils.require_a_service_provider(input, [:apn])
+    Utils.require_a_service_provider(input, [:apn, :another])
+
+    assert_raise ArgumentError, fn ->
+      Utils.require_a_service_provider(input, [:apn, :another, :yet_another])
+    end
+
+    assert_raise ArgumentError, fn -> Utils.require_a_service_provider(input, [:yet_another]) end
+  end
+end


### PR DESCRIPTION
This finishes a previous refactor that added `normalize/1` to the modem
implementations. Since that function existed, also having the special
case for validating service providers seemed silly. This adds a common
case service provider validator that gives a somewhat helpful message if
you mess it up.