### PR TITLE
Monitor cell network parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,26 @@ Here's an example with a service provider list:
   }
 ```
 
+## VintageNet Properties
+
+In addition to the common `vintage_net` properties for all interface types, this
+technology reports one or more of the following:
+
+| Property      | Values         | Description                   |
+| ------------- | -------------- | ----------------------------- |
+| `signal_rssi` | `0-31` or `99` | An integer between 0-31 or 99 |
+| `lac`         | `0-65533`      | The Location Area Code (lac) for the current cell |
+| `cid`         | `0-268435455`  | The Cell ID (cid) for the current cell |
+| `mcc`         | `0-999`        | Mobile Country Code for the network |
+| `mnc`         | `0-999`        | Mobile Network Code for the network |
+| `network`     | string         | The network operator's name |
+| `access_technology` | string   | The technology currently in use to connect to the network |
+| `band`        | string         | The frequency band in use |
+| `channel`     | integer        | An integer that indicates the channel that's in use |
+
+Please check your modem implementation for which properties it supports or run
+`VintageNet.get_by_prefix(["interface", "ppp0"])` and see what happens.
+
 ## Custom modems
 
 `VintageNetMobile` allows you add custom modem implementations if the built-in
@@ -92,6 +112,38 @@ In order to implement a modem, you will need:
 
 One strategy is to see if there's an existing modem that looks similar to yours
 and modify it.
+
+## Serial AT command debugging
+
+When porting `vintage_net_mobile` to a new cell modem, it can be useful to
+experiment with the modem directly. To do this, add a dependency to
+[elixircom](https://github.com/mattludwigs/elixircom), rebuild, and then on the
+device, you can do things like this:
+
+```elixir
+iex> Elixircom.run("/dev/ttyUSB2", speed: 115200)
+```
+
+Will allow you to run AT commands. To test everything is okay:
+
+```elixir
+iex> Elixircom.run("/dev/ttyUSB2", speed: 115200)
+# type at and press enter
+
+OK
+```
+
+Your modem should supply a complete list of AT commands. The following may be
+useful:
+
+| Command   | Description                                      |
+| --------- | ------------------------------------------------ |
+| at+csq    | Signal Strength                                  |
+| at+csq=?  | Query supported signal strength format           |
+| at+cfun?  | Level of functionality                           |
+| at+cfun=? | Query supported functionality levels             |
+| at+creg?  | Check if the modem has registered to a provider. |
+| at+cgreg? | Same as above for some modems                    |
 
 ## System requirements
 
@@ -141,40 +193,3 @@ and then create `busybox.fragment` with the following:
 CONFIG_MKNOD=y
 CONFIG_WC=y
 ```
-
-## VintageNet Properties
-
-In addition to the common `vintage_net` properties for all interface types, this technology reports the following:
-
-| Property      | Values         | Description                   |
-| ------------- | -------------- | ----------------------------- |
-| `signal_rssi` | `0-31` or `99` | An integer between 0-31 or 99 |
-
-## Serial AT command debugging
-
-If you are running this on a nerves device and have
-[elixircom](https://github.com/mattludwigs/elixircom) installed:
-
-```elixir
-iex> Elixircom.run("/dev/ttyUSB2", speed: 115200)
-```
-
-Will allow you to run AT commands. To test everything is okay:
-
-```elixir
-iex> Elixircom.run("/dev/ttyUSB2", speed: 115200)
-# type at and press enter
-
-OK
-```
-
-| Command   | Description                                      |
-| --------- | ------------------------------------------------ |
-| at+csq    | Signal Strength                                  |
-| at+csq=?  | Query supported signal strength format           |
-| at+cfun?  | Level of functionality                           |
-| at+cfun=? | Query supported functionality levels             |
-| at+creg?  | Check if the modem has registered to a provider. |
-| at+cgreg? | Same as above for some modems                    |
-
-`VintageNetMobile` makes it easy to add cellular support to your device.

--- a/lib/vintage_net_mobile/cell_monitor.ex
+++ b/lib/vintage_net_mobile/cell_monitor.ex
@@ -1,0 +1,191 @@
+defmodule VintageNetMobile.CellMonitor do
+  @moduledoc """
+  Monitor cell network information
+
+  This monitor queries the modem for cell network information and posts it to
+  VintageNet properties.
+
+  The following properties are reported:
+
+  | Property      | Values         | Description                   |
+  | ------------- | -------------- | ----------------------------- |
+  | `lac`         | `0-65533`      | The Location Area Code (lac) for the current cell |
+  | `cid`         | `0-268435455`  | The Cell ID (cid) for the current cell |
+  | `mcc`         | `0-999`        | Mobile Country Code for the network |
+  | `mnc`         | `0-999`        | Mobile Network Code for the network |
+  | `network`     | string         | The network operator's name |
+  | `access_technology` | string   | The technology currently in use to connect to the network |
+  | `band`        | string         | The frequency band in use |
+  | `channel`     | integer        | An integer that indicates the channel that's in use |
+  """
+  use GenServer
+  require Logger
+  alias VintageNet.PropertyTable
+  alias VintageNetMobile.{ExChat, ATParser}
+
+  defmodule State do
+    @moduledoc false
+
+    defstruct up: false, ifname: nil, tty: nil
+  end
+
+  @spec start_link([keyword()]) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(opts) do
+    ifname = Keyword.fetch!(opts, :ifname)
+    tty = Keyword.fetch!(opts, :tty)
+
+    VintageNet.subscribe(["interface", ifname, "connection"])
+    us = self()
+    ExChat.register(tty, "+CREG:", fn message -> send(us, {:handle_creg, message}) end)
+    ExChat.register(tty, "+QSPN:", fn message -> send(us, {:handle_qspn, message}) end)
+    ExChat.register(tty, "+QNWINFO:", fn message -> send(us, {:handle_qnwinfo, message}) end)
+
+    _ = :timer.send_interval(30_000, :poll)
+
+    {:ok, %State{ifname: ifname, tty: tty}}
+  end
+
+  @impl true
+  def handle_info({:handle_creg, message}, state) do
+    message
+    |> ATParser.parse()
+    |> creg_response_to_registration()
+    |> post_registration(state.ifname)
+
+    {:noreply, state}
+  end
+
+  def handle_info({:handle_qspn, message}, state) do
+    message
+    |> ATParser.parse()
+    |> qspn_response_to_network()
+    |> post_network(state.ifname)
+
+    {:noreply, state}
+  end
+
+  def handle_info({:handle_qnwinfo, message}, state) do
+    message
+    |> ATParser.parse()
+    |> qnwinfo_response_to_info()
+    |> post_qnwinfo(state.ifname)
+
+    {:noreply, state}
+  end
+
+  def handle_info(
+        {VintageNet, ["interface", ifname, "connection"], _old, :internet, _meta},
+        %{ifname: ifname} = state
+      ) do
+    new_state = %{state | up: true}
+
+    # Set the CREG report format just in case it hasn't been set.
+    :ok = ExChat.send(new_state.tty, "AT+CREG=2", timeout: 1000)
+
+    poll(new_state)
+
+    {:noreply, new_state}
+  end
+
+  def handle_info(
+        {VintageNet, ["interface", ifname, "connection"], _old, _not_internet, _meta},
+        %{ifname: ifname} = state
+      ) do
+    # Clear out properties!
+
+    {:noreply, %{state | up: false}}
+  end
+
+  def handle_info(:poll, state) do
+    poll(state)
+    {:noreply, state}
+  end
+
+  defp poll(%{up: true} = state) do
+    :ok = ExChat.send(state.tty, "AT+CREG?", timeout: 1000)
+    :ok = ExChat.send(state.tty, "AT+QNWINFO", timeout: 1000)
+    :ok = ExChat.send(state.tty, "AT+QSPN", timeout: 1000)
+  end
+
+  defp poll(_state), do: :ok
+
+  defp creg_response_to_registration({:ok, _header, [2, stat, lac, ci, act]})
+       when is_integer(stat) and is_binary(lac) and is_binary(ci) and is_integer(act) do
+    %{stat: stat, lac: safe_hex_to_int(lac), ci: safe_hex_to_int(ci), act: act}
+  end
+
+  defp creg_response_to_registration(malformed) do
+    _ = Logger.warn("Unexpected AT+CREG? response: #{inspect(malformed)}")
+    %{stat: 0, lac: 0, ci: 0, act: 0}
+  end
+
+  defp qspn_response_to_network({:ok, _header, [fnn, snn, spn, alphabet, plmn]})
+       when is_binary(fnn) and is_binary(snn) and is_binary(spn) and is_integer(alphabet) and
+              is_binary(plmn) do
+    {mcc, mnc} = plmn_to_mcc_mnc(plmn)
+    %{network_name: fnn, mcc: mcc, mnc: mnc}
+  end
+
+  defp qspn_response_to_network(malformed) do
+    _ = Logger.warn("Unexpected AT+QSPN response: #{inspect(malformed)}")
+    %{network_name: "", mcc: 0, mnc: 0}
+  end
+
+  defp qnwinfo_response_to_info({:ok, _header, [act, oper, band, channel]})
+       when is_binary(act) and is_binary(oper) and is_binary(band) and is_integer(channel) do
+    %{act: act, band: band, channel: channel}
+  end
+
+  defp qnwinfo_response_to_info(malformed) do
+    _ = Logger.warn("Unexpected AT+QWINFO response: #{inspect(malformed)}")
+    %{act: "UNKNOWN", band: "", channel: 0}
+  end
+
+  defp plmn_to_mcc_mnc(<<mcc::3-bytes, mnc::3-bytes>>) do
+    {safe_decimal_to_int(mcc), safe_decimal_to_int(mnc)}
+  end
+
+  defp plmn_to_mcc_mnc(<<mcc::3-bytes, mnc::2-bytes>>) do
+    {safe_decimal_to_int(mcc), safe_decimal_to_int(mnc)}
+  end
+
+  defp plmn_to_mcc_mnc(other) do
+    {safe_decimal_to_int(other), 0}
+  end
+
+  defp safe_hex_to_int(hex_string) do
+    case Integer.parse(hex_string, 16) do
+      {value, ""} -> value
+      _other -> 0
+    end
+  end
+
+  defp safe_decimal_to_int(string) do
+    case Integer.parse(string) do
+      {value, ""} -> value
+      _other -> 0
+    end
+  end
+
+  defp post_registration(%{lac: lac, ci: ci}, ifname) do
+    PropertyTable.put(VintageNet, ["interface", ifname, "mobile", "lac"], lac)
+    PropertyTable.put(VintageNet, ["interface", ifname, "mobile", "cid"], ci)
+  end
+
+  defp post_network(%{network_name: name, mcc: mcc, mnc: mnc}, ifname) do
+    PropertyTable.put(VintageNet, ["interface", ifname, "mobile", "network"], name)
+    PropertyTable.put(VintageNet, ["interface", ifname, "mobile", "mcc"], mcc)
+    PropertyTable.put(VintageNet, ["interface", ifname, "mobile", "mnc"], mnc)
+  end
+
+  defp post_qnwinfo(%{act: act, band: band, channel: channel}, ifname) do
+    PropertyTable.put(VintageNet, ["interface", ifname, "mobile", "access_technology"], act)
+    PropertyTable.put(VintageNet, ["interface", ifname, "mobile", "band"], band)
+    PropertyTable.put(VintageNet, ["interface", ifname, "mobile", "channel"], channel)
+  end
+end

--- a/lib/vintage_net_mobile/modem/quectel_EC25.ex
+++ b/lib/vintage_net_mobile/modem/quectel_EC25.ex
@@ -23,6 +23,38 @@ defmodule VintageNetMobile.Modem.QuectelEC25 do
   If multiple service providers are configured, this implementation only
   attempts to connect to the first one.
 
+  Example of supported properties:
+
+  ```elixir
+  iex> VintageNet.get_by_prefix(["interface", "ppp0"])
+  [
+    {["interface", "ppp0", "addresses"],
+    [
+      %{
+        address: {10, 64, 64, 64},
+        family: :inet,
+        netmask: {255, 255, 255, 255},
+        prefix_length: 32,
+        scope: :universe
+      }
+    ]},
+    {["interface", "ppp0", "connection"], :internet},
+    {["interface", "ppp0", "lower_up"], true},
+    {["interface", "ppp0", "mobile", "access_technology"], "FDD LTE"},
+    {["interface", "ppp0", "mobile", "band"], "LTE BAND 4"},
+    {["interface", "ppp0", "mobile", "channel"], 2300},
+    {["interface", "ppp0", "mobile", "cid"], 11303407},
+    {["interface", "ppp0", "mobile", "lac"], 10234},
+    {["interface", "ppp0", "mobile", "mcc"], 360},
+    {["interface", "ppp0", "mobile", "mnc"], 200},
+    {["interface", "ppp0", "mobile", "network"], "Twilio"},
+    {["interface", "ppp0", "mobile", "signal_rssi"], 22},
+    {["interface", "ppp0", "present"], true},
+    {["interface", "ppp0", "state"], :configured},
+    {["interface", "ppp0", "type"], VintageNetMobile}
+  ]
+  ```
+
   ## Required Linux kernel options
 
   * CONFIG_USB_SERIAL=m
@@ -32,7 +64,7 @@ defmodule VintageNetMobile.Modem.QuectelEC25 do
   * CONFIG_USB_NET_QMI_WWAN=m
   """
 
-  alias VintageNetMobile.{ExChat, SignalMonitor, PPPDConfig, Chatscript}
+  alias VintageNetMobile.{ExChat, SignalMonitor, CellMonitor, PPPDConfig, Chatscript}
   alias VintageNetMobile.Modem.Utils
   alias VintageNet.Interface.RawConfig
 
@@ -50,7 +82,8 @@ defmodule VintageNetMobile.Modem.QuectelEC25 do
 
     child_specs = [
       {ExChat, [tty: "ttyUSB2", speed: 9600]},
-      {SignalMonitor, [ifname: ifname, tty: "ttyUSB2"]}
+      {SignalMonitor, [ifname: ifname, tty: "ttyUSB2"]},
+      {CellMonitor, [ifname: ifname, tty: "ttyUSB2"]}
     ]
 
     %RawConfig{

--- a/test/vintage_net_mobile/modem/quectel_EC25_test.exs
+++ b/test/vintage_net_mobile/modem/quectel_EC25_test.exs
@@ -68,7 +68,8 @@ defmodule VintageNetMobile.Modem.QuectelEC25Test do
            [env: [{"PRIV_DIR", priv_dir}, {"LD_PRELOAD", Path.join(priv_dir, "pppd_shim.so")}]]
          ]},
         {VintageNetMobile.ExChat, [tty: "ttyUSB2", speed: 9600]},
-        {VintageNetMobile.SignalMonitor, [ifname: "ppp0", tty: "ttyUSB2"]}
+        {VintageNetMobile.SignalMonitor, [ifname: "ppp0", tty: "ttyUSB2"]},
+        {VintageNetMobile.CellMonitor, [ifname: "ppp0", tty: "ttyUSB2"]}
       ]
     }
 


### PR DESCRIPTION
This is enabled for the EC25. It likely works on other modems and can
be applied to them after testing.

Here's an example:

```elixir
  iex> VintageNet.get_by_prefix(["interface", "ppp0"])
  [
    {["interface", "ppp0", "addresses"],
    [
      %{
        address: {10, 64, 64, 64},
        family: :inet,
        netmask: {255, 255, 255, 255},
        prefix_length: 32,
        scope: :universe
      }
    ]},
    {["interface", "ppp0", "connection"], :internet},
    {["interface", "ppp0", "lower_up"], true},
    {["interface", "ppp0", "mobile", "access_technology"], "FDD LTE"},
    {["interface", "ppp0", "mobile", "band"], "LTE BAND 4"},
    {["interface", "ppp0", "mobile", "channel"], 2300},
    {["interface", "ppp0", "mobile", "cid"], 11303407},
    {["interface", "ppp0", "mobile", "lac"], 10234},
    {["interface", "ppp0", "mobile", "mcc"], 360},
    {["interface", "ppp0", "mobile", "mnc"], 200},
    {["interface", "ppp0", "mobile", "network"], "Twilio"},
    {["interface", "ppp0", "mobile", "signal_rssi"], 22},
    {["interface", "ppp0", "present"], true},
    {["interface", "ppp0", "state"], :configured},
    {["interface", "ppp0", "type"], VintageNetMobile}
  ]
```

By plugging the `cid` and `lac` into a cell tower database, you can find
approximately where your modem is.