### PR TITLE
Add signal strength calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ technology reports one or more of the following:
 
 | Property      | Values         | Description                   |
 | ------------- | -------------- | ----------------------------- |
+| `signal_asu`  | `0-31,99`      | Reported Arbitrary Strength Unit (ASU) |
+| `signal_4bars` | `0-4`         | The signal level in "bars"    |
+| `signal_dbm`  | `-144 - -44`   | The signal level in dBm. Interpretation depends on the connection technology. |
 | `signal_rssi` | `0-31` or `99` | An integer between 0-31 or 99 |
 | `lac`         | `0-65533`      | The Location Area Code (lac) for the current cell |
 | `cid`         | `0-268435455`  | The Cell ID (cid) for the current cell |

--- a/lib/vintage_net_mobile.ex
+++ b/lib/vintage_net_mobile.ex
@@ -87,6 +87,13 @@ defmodule VintageNetMobile do
           optional(:usage) => :eps_bearer | :pdp
         }
 
+  @typedoc """
+  Radio Access Technology (RAT)
+
+  These define how to connect to the cellular network.
+  """
+  @type rat :: :gsm | :td_scdma | :wcdma | :lte | :cdma | :lte_cat_nb1 | :lte_cat_m1
+
   @impl true
   def normalize(%{type: __MODULE__, vintage_net_mobile: mobile} = config) do
     modem = Map.fetch!(mobile, :modem)

--- a/lib/vintage_net_mobile/asu_calculator.ex
+++ b/lib/vintage_net_mobile/asu_calculator.ex
@@ -1,0 +1,80 @@
+defmodule VintageNetMobile.ASUCalculator do
+  @moduledoc """
+  Convert raw ASU values to friendlier units
+
+  See https://en.wikipedia.org/wiki/Mobile_phone_signal#ASU for
+  more information.
+
+  The following conversions are done:
+
+  * dBm
+  * Number of "bars" out of 4 bars
+  """
+
+  @typedoc """
+  Number of bars out of 4 to show in a UI
+  """
+  @type bars :: 0..4
+
+  @typedoc """
+  dBm
+  """
+  @type dbm :: neg_integer()
+
+  @typedoc """
+  GSM ASU values
+
+  ASU values map to RSSI. 99 means unknown
+  """
+  @type gsm_asu :: 0..31 | 99
+
+  @typedoc """
+  UMTS ASU values
+
+  ASU values map to RSCP
+  """
+  @type umts_asu :: 0..90 | 255
+
+  @typedoc """
+  LTE ASU values
+
+  ASU values map to RSRP
+
+  https://arimas.com/78-rsrp-and-rsrq-measurement-in-lte/
+  """
+  @type lte_asu :: 0..97
+
+  @doc """
+  Compute signal level numbers from a GSM ASU
+
+  The `AT+CSQ` command should report ASU values in this format.
+  """
+  @spec from_gsm_asu(gsm_asu()) :: %{asu: gsm_asu(), dbm: dbm(), bars: bars()}
+  def from_gsm_asu(asu) do
+    clamped_asu = clamp_gsm_asu(asu)
+    %{asu: asu, dbm: gsm_asu_to_dbm(clamped_asu), bars: gsm_asu_to_bars(clamped_asu)}
+  end
+
+  defp gsm_asu_to_dbm(asu) when asu == 99, do: -113
+
+  defp gsm_asu_to_dbm(asu) do
+    asu * 2 - 113
+  end
+
+  defp gsm_asu_to_bars(asu) when asu == 99, do: 0
+  defp gsm_asu_to_bars(asu) when asu <= 9, do: 1
+  defp gsm_asu_to_bars(asu) when asu <= 14, do: 2
+  defp gsm_asu_to_bars(asu) when asu <= 19, do: 3
+  defp gsm_asu_to_bars(asu) when asu <= 30, do: 4
+
+  # defp lte_rssi_to_bars(rssi) when rssi > -65, do: 4
+  # defp lte_rssi_to_bars(rssi) when rssi > -75, do: 3
+  # defp lte_rssi_to_bars(rssi) when rssi > -85, do: 2
+  # defp lte_rssi_to_bars(_rssi), do: 1
+
+  # Clamp ASU to the allowed values
+  defp clamp_gsm_asu(asu) when asu < 0, do: 0
+  defp clamp_gsm_asu(asu) when asu == 99, do: 99
+  defp clamp_gsm_asu(asu) when asu > 30, do: 30
+  defp clamp_gsm_asu(asu), do: asu
+end

--- a/lib/vintage_net_mobile/modem/quectel_BG96.ex
+++ b/lib/vintage_net_mobile/modem/quectel_BG96.ex
@@ -40,13 +40,6 @@ defmodule VintageNetMobile.Modem.QuectelBG96 do
   * CONFIG_USB_NET_QMI_WWAN=m
   """
 
-  @typedoc """
-  Radio Access Technology (RAT)
-
-  These define how to connect to the cellular network.
-  """
-  @type rat :: :gsm | :td_scdma | :wcdma | :lte | :cdma | :lte_cat_nb1 | :lte_cat_m1
-
   alias VintageNet.Interface.RawConfig
   alias VintageNetMobile.{ExChat, SignalMonitor, PPPDConfig, Chatscript}
   alias VintageNetMobile.Modem.Utils
@@ -64,6 +57,7 @@ defmodule VintageNetMobile.Modem.QuectelBG96 do
     %{config | vintage_net_mobile: new_mobile}
   end
 
+  @spec normalize_scan(nil | [VintageNetMobile.rat()]) :: [VintageNetMobile.rat()]
   defp normalize_scan(nil), do: nil
 
   defp normalize_scan(rat_list) when is_list(rat_list) do

--- a/lib/vintage_net_mobile/modem/quectel_EC25.ex
+++ b/lib/vintage_net_mobile/modem/quectel_EC25.ex
@@ -48,7 +48,9 @@ defmodule VintageNetMobile.Modem.QuectelEC25 do
     {["interface", "ppp0", "mobile", "mcc"], 360},
     {["interface", "ppp0", "mobile", "mnc"], 200},
     {["interface", "ppp0", "mobile", "network"], "Twilio"},
-    {["interface", "ppp0", "mobile", "signal_rssi"], 22},
+    {["interface", "ppp0", "mobile", "signal_asu"], 21},
+    {["interface", "ppp0", "mobile", "signal_4bars"], 4},
+    {["interface", "ppp0", "mobile", "signal_dbm"], -71},
     {["interface", "ppp0", "present"], true},
     {["interface", "ppp0", "state"], :configured},
     {["interface", "ppp0", "type"], VintageNetMobile}

--- a/test/vintage_net_mobile/asu_calculator_test.exs
+++ b/test/vintage_net_mobile/asu_calculator_test.exs
@@ -1,0 +1,26 @@
+defmodule VintageNetMobile.ASUCalculatorTest do
+  use ExUnit.Case
+  alias VintageNetMobile.ASUCalculator
+
+  test "computes gsm dbm" do
+    assert ASUCalculator.from_gsm_asu(2).dbm == -109
+    assert ASUCalculator.from_gsm_asu(9).dbm == -95
+    assert ASUCalculator.from_gsm_asu(15).dbm == -83
+    assert ASUCalculator.from_gsm_asu(30).dbm == -53
+
+    assert ASUCalculator.from_gsm_asu(99).dbm == -113
+
+    # Bad values
+    assert ASUCalculator.from_gsm_asu(-100).dbm == -113
+    assert ASUCalculator.from_gsm_asu(31).dbm == -53
+  end
+
+  test "computes gsm bars" do
+    assert ASUCalculator.from_gsm_asu(2).bars == 1
+    assert ASUCalculator.from_gsm_asu(9).bars == 1
+    assert ASUCalculator.from_gsm_asu(14).bars == 2
+    assert ASUCalculator.from_gsm_asu(15).bars == 3
+    assert ASUCalculator.from_gsm_asu(30).bars == 4
+    assert ASUCalculator.from_gsm_asu(99).bars == 0
+  end
+end


### PR DESCRIPTION
This improves the signal quality property by:

1. Renaming the current RSSI report to ASU (arbitrary strength unit) since that's more accurate. ASU's are confusing since they change definition based on GPRS, UMTS, and LTE. And they appear to change based on modem. ASUs are still reported since if anyone doesn't trust our calculations, they can use it raw.
2. Add `signal_4bars` that gives a number 0-4 that maps to the number of bars that you'd display on a cell phone to show signal strength. The conversion is subjective, but it's a start.
3. Add `signal_dbm` that converts ASU to dBm. This is unfortunately confusing too since it's only RSSI on GPRS connections. UMTS changed what's being measured and then LTE changed it again.
4. Added references for anyone maintaining the code or getting confused by the reports

Here's an example:

```
   {["interface", "ppp0", "mobile", "signal_asu"], 21},
   {["interface", "ppp0", "mobile", "signal_4bars"], 4},
   {["interface", "ppp0", "mobile", "signal_dbm"], -71},
```
