### PR TITLE
Refactor ICCID query to module; add IMSI

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ technology reports one or more of the following:
 | `access_technology` | string   | The technology currently in use to connect to the network |
 | `band`        | string         | The frequency band in use |
 | `channel`     | integer        | An integer that indicates the channel that's in use |
-| `iccid `      | string          | The Integrated Circuit Card Identifier |
-
+| `iccid`       | string         | The Integrated Circuit Card Identifier (ICCID) |
+| `imsi`        | string         | The International Mobile Subscriber Identity (IMSI) |
 
 Please check your modem implementation for which properties it supports or run
 `VintageNet.get_by_prefix(["interface", "ppp0"])` and see what happens.

--- a/lib/vintage_net_mobile/cell_monitor.ex
+++ b/lib/vintage_net_mobile/cell_monitor.ex
@@ -99,8 +99,8 @@ defmodule VintageNetMobile.CellMonitor do
     new_state = %{state | up: true}
 
     # Set the CREG report format just in case it hasn't been set.
-    :ok = ExChat.send(new_state.tty, "AT+CREG=2", timeout: 1000)
-    :ok = ExChat.send(new_state.tty, "AT+QCCID", timeout: 500)
+    {:ok, _} = ExChat.send(new_state.tty, "AT+CREG=2", timeout: 1000)
+    {:ok, _} = ExChat.send(new_state.tty, "AT+QCCID", timeout: 500)
 
     poll(new_state)
 

--- a/lib/vintage_net_mobile/cell_monitor.ex
+++ b/lib/vintage_net_mobile/cell_monitor.ex
@@ -17,15 +17,12 @@ defmodule VintageNetMobile.CellMonitor do
   | `access_technology` | string   | The technology currently in use to connect to the network |
   | `band`        | string         | The frequency band in use |
   | `channel`     | integer        | An integer that indicates the channel that's in use |
-  | `iccid `      | string          | The Integrated Circuit Card Identifier |
 
   """
   use GenServer
   require Logger
   alias VintageNet.PropertyTable
   alias VintageNetMobile.{ExChat, ATParser}
-
-  @iccid_unknown "Not provided"
 
   defmodule State do
     @moduledoc false
@@ -48,7 +45,6 @@ defmodule VintageNetMobile.CellMonitor do
     ExChat.register(tty, "+CREG:", fn message -> send(us, {:handle_creg, message}) end)
     ExChat.register(tty, "+QSPN:", fn message -> send(us, {:handle_qspn, message}) end)
     ExChat.register(tty, "+QNWINFO:", fn message -> send(us, {:handle_qnwinfo, message}) end)
-    ExChat.register(tty, "+QCCID", fn message -> send(us, {:handle_qccid, message}) end)
 
     _ = :timer.send_interval(30_000, :poll)
 
@@ -83,15 +79,6 @@ defmodule VintageNetMobile.CellMonitor do
     {:noreply, state}
   end
 
-  def handle_info({:handle_qccid, message}, state) do
-    message
-    |> ATParser.parse()
-    |> iccid_response_to_qccid()
-    |> post_iccid(state.ifname)
-
-    {:noreply, state}
-  end
-
   def handle_info(
         {VintageNet, ["interface", ifname, "connection"], _old, :internet, _meta},
         %{ifname: ifname} = state
@@ -100,7 +87,6 @@ defmodule VintageNetMobile.CellMonitor do
 
     # Set the CREG report format just in case it hasn't been set.
     {:ok, _} = ExChat.send(new_state.tty, "AT+CREG=2", timeout: 1000)
-    {:ok, _} = ExChat.send(new_state.tty, "AT+QCCID", timeout: 500)
 
     poll(new_state)
 
@@ -161,15 +147,6 @@ defmodule VintageNetMobile.CellMonitor do
     %{act: "UNKNOWN", band: "", channel: 0}
   end
 
-  defp iccid_response_to_qccid({:ok, "+QCCID: ", [id]}) do
-    id
-  end
-
-  defp iccid_response_to_qccid(anything_else) do
-    _ = Logger.warn("Unexpected AT+QCCID response: #{inspect(anything_else)}")
-    @iccid_unknown
-  end
-
   defp plmn_to_mcc_mnc(<<mcc::3-bytes, mnc::3-bytes>>) do
     {safe_decimal_to_int(mcc), safe_decimal_to_int(mnc)}
   end
@@ -211,9 +188,5 @@ defmodule VintageNetMobile.CellMonitor do
     PropertyTable.put(VintageNet, ["interface", ifname, "mobile", "access_technology"], act)
     PropertyTable.put(VintageNet, ["interface", ifname, "mobile", "band"], band)
     PropertyTable.put(VintageNet, ["interface", ifname, "mobile", "channel"], channel)
-  end
-
-  defp post_iccid(iccid, ifname) do
-    PropertyTable.put(VintageNet, ["interface", ifname, "mobile", "iccid"], iccid)
   end
 end

--- a/lib/vintage_net_mobile/ex_chat.ex
+++ b/lib/vintage_net_mobile/ex_chat.ex
@@ -47,8 +47,10 @@ defmodule VintageNetMobile.ExChat do
 
   @doc """
   Send a command to the modem
+
+  On success, this returns a list of the lines received back from the modem.
   """
-  @spec send(binary(), iodata(), Core.send_options()) :: :ok | {:error, any()}
+  @spec send(binary(), iodata(), Core.send_options()) :: {:ok, [binary()]} | {:error, any()}
   def send(tty_name, command, options \\ []) do
     # Make sure we wait long enough for the command to be processed by the modem
     command_timeout = Keyword.get(options, :timeout, 10000) + 500
@@ -66,7 +68,7 @@ defmodule VintageNetMobile.ExChat do
   @spec send_best_effort(binary(), iodata(), Core.send_options()) :: :ok
   def send_best_effort(tty_name, command, options \\ []) do
     case send(tty_name, command, options) do
-      :ok ->
+      {:ok, _response} ->
         :ok
 
       error ->
@@ -78,7 +80,7 @@ defmodule VintageNetMobile.ExChat do
   @doc """
   Register a callback function for reports
   """
-  @spec register(binary(), String.t(), function()) :: :ok
+  @spec register(binary(), binary(), function()) :: :ok
   def register(tty_name, type, callback) do
     GenServer.call(server_name(tty_name), {:register, type, callback})
   end

--- a/lib/vintage_net_mobile/ex_chat/request.ex
+++ b/lib/vintage_net_mobile/ex_chat/request.ex
@@ -17,13 +17,13 @@ defmodule VintageNetMobile.ExChat.Request do
 
   @type t :: %__MODULE__{
           id: any(),
-          request: String.t(),
-          success: String.t(),
-          errors: [String.t()],
+          request: binary(),
+          success: binary(),
+          errors: [binary()],
           timeout: non_neg_integer()
         }
 
-  @spec new(String.t(), any(), keyword()) :: t()
+  @spec new(binary(), any(), keyword()) :: t()
   def new(request, who, opts) do
     %__MODULE__{
       id: who,

--- a/lib/vintage_net_mobile/ex_chat/state.ex
+++ b/lib/vintage_net_mobile/ex_chat/state.ex
@@ -6,12 +6,14 @@ defmodule VintageNetMobile.ExChat.State do
   defstruct queued_requests: :queue.new(),
             request: nil,
             request_timer: nil,
+            responses: [],
             listeners: []
 
   @type t :: %__MODULE__{
           queued_requests: :queue.queue(Request.t()),
           request: Request.t() | nil,
           request_timer: reference() | nil,
-          listeners: [{String.t(), any()}]
+          responses: [binary()],
+          listeners: [{binary(), any()}]
         }
 end

--- a/lib/vintage_net_mobile/modem/quectel_BG96.ex
+++ b/lib/vintage_net_mobile/modem/quectel_BG96.ex
@@ -75,7 +75,7 @@ defmodule VintageNetMobile.Modem.QuectelBG96 do
   """
 
   alias VintageNet.Interface.RawConfig
-  alias VintageNetMobile.{ExChat, SignalMonitor, CellMonitor, PPPDConfig, Chatscript}
+  alias VintageNetMobile.{CellMonitor, Chatscript, ExChat, ModemInfo, PPPDConfig, SignalMonitor}
   alias VintageNetMobile.Modem.Utils
 
   @impl true
@@ -117,10 +117,13 @@ defmodule VintageNetMobile.Modem.QuectelBG96 do
       {Chatscript.path(ifname, opts), chatscript(mobile)}
     ]
 
+    tty = "ttyUSB2"
+
     child_specs = [
-      {ExChat, [tty: "ttyUSB2", speed: 9600]},
-      {SignalMonitor, [ifname: ifname, tty: "ttyUSB2"]},
-      {CellMonitor, [ifname: ifname, tty: "ttyUSB2"]}
+      {ExChat, [tty: tty, speed: 9600]},
+      {SignalMonitor, [ifname: ifname, tty: tty]},
+      {CellMonitor, [ifname: ifname, tty: tty]},
+      {ModemInfo, [ifname: ifname, tty: tty]}
     ]
 
     %RawConfig{

--- a/lib/vintage_net_mobile/modem_info.ex
+++ b/lib/vintage_net_mobile/modem_info.ex
@@ -17,7 +17,7 @@ defmodule VintageNetMobile.ModemInfo do
   alias VintageNet.PropertyTable
   alias VintageNetMobile.{ExChat, ATParser}
 
-  @iccid_unknown "Not provided"
+  @unknown "Unknown"
 
   defmodule State do
     @moduledoc false
@@ -67,7 +67,7 @@ defmodule VintageNetMobile.ModemInfo do
 
   defp iccid_response_to_qccid(anything_else) do
     _ = Logger.warn("Unexpected AT+QCCID response: #{inspect(anything_else)}")
-    @iccid_unknown
+    @unknown
   end
 
   defp post_iccid(iccid, ifname) do

--- a/lib/vintage_net_mobile/modem_info.ex
+++ b/lib/vintage_net_mobile/modem_info.ex
@@ -1,0 +1,89 @@
+defmodule VintageNetMobile.ModemInfo do
+  @moduledoc """
+  Query the modem for device and SIM information
+
+  This monitor queries the modem for information about itself and its SIM and
+  posts it to VintageNet properties.
+
+  The following properties are reported:
+
+  | Property      | Values         | Description                   |
+  | ------------- | -------------- | ----------------------------- |
+  | `iccid `      | string         | The Integrated Circuit Card Identifier |
+
+  """
+  use GenServer
+  require Logger
+  alias VintageNet.PropertyTable
+  alias VintageNetMobile.{ExChat, ATParser}
+
+  @iccid_unknown "Not provided"
+
+  defmodule State do
+    @moduledoc false
+
+    defstruct up: false, ifname: nil, tty: nil
+  end
+
+  @spec start_link([keyword()]) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(opts) do
+    ifname = Keyword.fetch!(opts, :ifname)
+    tty = Keyword.fetch!(opts, :tty)
+
+    VintageNet.subscribe(["interface", ifname, "connection"])
+    us = self()
+    ExChat.register(tty, "+QCCID", fn message -> send(us, {:handle_qccid, message}) end)
+
+    {:ok, %State{ifname: ifname, tty: tty}}
+  end
+
+  @impl true
+  def handle_info({:handle_qccid, message}, state) do
+    message
+    |> ATParser.parse()
+    |> iccid_response_to_qccid()
+    |> post_iccid(state.ifname)
+
+    {:stop, :normal}
+  end
+
+  def handle_info(
+        {VintageNet, ["interface", ifname, "connection"], _old, :internet, _meta},
+        %{ifname: ifname} = state
+      ) do
+    new_state = %{state | up: true}
+
+    # Set the CREG report format just in case it hasn't been set.
+    {:ok, _} = ExChat.send(new_state.tty, "ATE0", timeout: 500)
+    {:ok, _} = ExChat.send(new_state.tty, "AT+QCCID", timeout: 500)
+
+    {:noreply, new_state}
+  end
+
+  def handle_info(
+        {VintageNet, ["interface", ifname, "connection"], _old, _not_internet, _meta},
+        %{ifname: ifname} = state
+      ) do
+    # Clear out properties!
+
+    {:noreply, %{state | up: false}}
+  end
+
+  defp iccid_response_to_qccid({:ok, "+QCCID: ", [id]}) do
+    id
+  end
+
+  defp iccid_response_to_qccid(anything_else) do
+    _ = Logger.warn("Unexpected AT+QCCID response: #{inspect(anything_else)}")
+    @iccid_unknown
+  end
+
+  defp post_iccid(iccid, ifname) do
+    PropertyTable.put(VintageNet, ["interface", ifname, "mobile", "iccid"], iccid)
+  end
+end

--- a/test/vintage_net_mobile/ex_chat_test.exs
+++ b/test/vintage_net_mobile/ex_chat_test.exs
@@ -15,7 +15,7 @@ defmodule VintageNetMobile.ExChatTest do
 
     us = self()
     :ok = ExChat.register(tty_name, "+CSQ:", fn message -> send(us, {:response, message}) end)
-    assert :ok == ExChat.send(tty_name, "AT+CSQ")
+    assert {:ok, []} == ExChat.send(tty_name, "AT+CSQ")
 
     assert_receive {:response, "+CSQ: 99,9"}
   end
@@ -66,7 +66,7 @@ defmodule VintageNetMobile.ExChatTest do
        [tty: tty_name, uart: VintageNetMobileTest.MockUART, uart_opts: [response_map: responses]]}
     )
 
-    assert capture_log(fn -> :ok = ExChat.send(tty_name, "AT+CSQ") end) =~
+    assert capture_log(fn -> {:ok, []} = ExChat.send(tty_name, "AT+CSQ") end) =~
              ~r/junk from a unit test/
   end
 

--- a/test/vintage_net_mobile/modem/quectel_BG96_test.exs
+++ b/test/vintage_net_mobile/modem/quectel_BG96_test.exs
@@ -84,7 +84,8 @@ defmodule VintageNetMobile.Modem.QuectelBG96Test do
          ]},
         {VintageNetMobile.ExChat, [tty: "ttyUSB2", speed: 9600]},
         {VintageNetMobile.SignalMonitor, [ifname: "ppp0", tty: "ttyUSB2"]},
-        {VintageNetMobile.CellMonitor, [ifname: "ppp0", tty: "ttyUSB2"]}
+        {VintageNetMobile.CellMonitor, [ifname: "ppp0", tty: "ttyUSB2"]},
+        {VintageNetMobile.ModemInfo, [ifname: "ppp0", tty: "ttyUSB2"]}
       ]
     }
 
@@ -160,7 +161,8 @@ defmodule VintageNetMobile.Modem.QuectelBG96Test do
          ]},
         {VintageNetMobile.ExChat, [tty: "ttyUSB2", speed: 9600]},
         {VintageNetMobile.SignalMonitor, [ifname: "ppp0", tty: "ttyUSB2"]},
-        {VintageNetMobile.CellMonitor, [ifname: "ppp0", tty: "ttyUSB2"]}
+        {VintageNetMobile.CellMonitor, [ifname: "ppp0", tty: "ttyUSB2"]},
+        {VintageNetMobile.ModemInfo, [ifname: "ppp0", tty: "ttyUSB2"]}
       ]
     }
 


### PR DESCRIPTION
The first commit adds support to for capturing non-notification responses from
the modem. The subsequent commits refactor the ICCID query so that it can run
before the connection gets established. This makes it possible to see the ICCID
if the connection isn't working. Finally, I added the IMSI query since it was
now easy-to-add.