### PR TITLE
Add sim selection to sierra modem

### DIFF
--- a/test/vintage_net_mobile/modem/sierra_HL8548_test.exs
+++ b/test/vintage_net_mobile/modem/sierra_HL8548_test.exs
@@ -10,6 +10,7 @@ defmodule VintageNetMobile.Modem.SierraHL8548Test do
     input = %{
       type: VintageNetMobile,
       vintage_net_mobile: %{
+        sim_select: 3,
         modem: SierraHL8548,
         service_providers: [%{apn: "choosethislteitissafe"}]
       }
@@ -44,6 +45,7 @@ defmodule VintageNetMobile.Modem.SierraHL8548Test do
          OK ATH
          OK ATZ
          OK ATQ0
+         OK AT+KSIMSEL=3
          OK AT+CGDCONT=1,"IP","choosethislteitissafe"
          OK ATDT*99***1#
          CONNECT ''


### PR DESCRIPTION
The sierra HL8548 modem supports dual sim selection. You can enable this feature by
  passing `sim_select: mode` in the configuration.

The options are
0 Disable SIM selection.
  1 Force to select the first external SIM. The presence of a second external
    SIM will be ignored.
  2 Force to select the second external SIM. The presence of a first external
    SIM will be ignored.
  3 Select the first external SIM if present else select the second external SIM
  4 Read the SIM presence status