### PR TITLE
Support modem and user chatscript additions

### DIFF
--- a/lib/vintage_net_mobile.ex
+++ b/lib/vintage_net_mobile.ex
@@ -14,17 +14,22 @@ defmodule VintageNetMobile do
     "ppp0",
     %{
       type: VintageNetMobile,
-      modem: your_modem,
-      modem_opts: %{},
-      service_providers: your_service_providers
+      vintage_net_mobile: %{
+        modem: VintageNetMobile.Modem.QuectelBG96,
+        service_providers: [%{apn: "super"}]
+      }
     }
   )
   ```
 
   The `:modem` key should be set to your modem implementation. Cellular modems
-  tend to be very similar. If `vintage_net_mobile` doesn't list your modem, see
-  the customizing section. It may just be a copy/paste away. See your module for
-  your modem for what options can be passed to `:modem_opts`.
+  tend to be very similar. If `vintage_net_mobile` doesn't support your modem, see
+  the customizing section. It may just be a copy/paste away. See your modem
+  module for modem-specific options. The following keys are supported by all modems:
+
+  * `:service_providers` - This is a list of service provider information
+  * `:chatscript_additions` - This is a string (technically iodata) for custom
+     modem initialization.
 
   The `:service_providers` key should be set to information provided by each of
   your service providers. It is common that this is a list of one item.
@@ -53,9 +58,12 @@ defmodule VintageNetMobile do
     %{
       type: VintageNetMobile,
       modem: your_modem,
-      service_providers: [
-        %{apn: "wireless.twilio.com"}
-      ]
+      vintage_net_mobile: %{
+        service_providers: [
+          %{apn: "wireless.twilio.com"}
+        ],
+        chatscript_additions: "OK AT"
+      }
     }
   ```
 
@@ -85,6 +93,18 @@ defmodule VintageNetMobile do
   @type service_provider_info :: %{
           required(:apn) => String.t(),
           optional(:usage) => :eps_bearer | :pdp
+        }
+
+  @typedoc """
+  The `:vintage_net_mobile` option in the configuration map
+
+  Only the `:service_providers` key must be specified. Modems may
+  add keys of their own.
+  """
+  @type mobile_options :: %{
+          required(:service_providers) => service_provider_info(),
+          optional(:chatscript_additions) => iodata(),
+          optional(any) => any
         }
 
   @typedoc """

--- a/lib/vintage_net_mobile/modem/quectel_BG96.ex
+++ b/lib/vintage_net_mobile/modem/quectel_BG96.ex
@@ -144,23 +144,15 @@ defmodule VintageNetMobile.Modem.QuectelBG96 do
     end
   end
 
-  defp chatscript(mobile) do
-    pdp_index = 1
-
-    [
-      Chatscript.prologue(),
-      Chatscript.set_pdp_context(pdp_index, hd(mobile.service_providers)),
-      script_additions(mobile),
-      Chatscript.connect(pdp_index)
-    ]
-    |> IO.iodata_to_binary()
+  defp chatscript(mobile_config) do
+    Chatscript.default(mobile_config, script_additions(mobile_config))
   end
 
   defp script_additions(nil), do: []
 
-  defp script_additions(mobile) when is_map(mobile) do
+  defp script_additions(mobile_config) when is_map(mobile_config) do
     [
-      scan_additions(Map.get(mobile, :scan))
+      scan_additions(Map.get(mobile_config, :scan))
     ]
   end
 

--- a/lib/vintage_net_mobile/modem/quectel_EC25.ex
+++ b/lib/vintage_net_mobile/modem/quectel_EC25.ex
@@ -80,7 +80,7 @@ defmodule VintageNetMobile.Modem.QuectelEC25 do
   def add_raw_config(raw_config, %{vintage_net_mobile: mobile} = _config, opts) do
     ifname = raw_config.ifname
 
-    files = [{Chatscript.path(ifname, opts), Chatscript.default(mobile.service_providers)}]
+    files = [{Chatscript.path(ifname, opts), Chatscript.default(mobile)}]
 
     child_specs = [
       {ExChat, [tty: "ttyUSB2", speed: 9600]},

--- a/lib/vintage_net_mobile/modem/sierra_HL8548.ex
+++ b/lib/vintage_net_mobile/modem/sierra_HL8548.ex
@@ -43,7 +43,7 @@ defmodule VintageNetMobile.Modem.SierraHL8548 do
   def add_raw_config(raw_config, %{vintage_net_mobile: mobile} = _config, opts) do
     ifname = raw_config.ifname
 
-    files = [{Chatscript.path(ifname, opts), Chatscript.default(mobile.service_providers)}]
+    files = [{Chatscript.path(ifname, opts), Chatscript.default(mobile)}]
 
     child_specs = [
       {ExChat, [tty: "ttyACM3", speed: 115_200]},

--- a/test/vintage_net_mobile/chatscript_test.exs
+++ b/test/vintage_net_mobile/chatscript_test.exs
@@ -27,6 +27,59 @@ defmodule VintageNetMobile.ChatscriptTest do
     CONNECT ''
     """
 
-    assert expected_chatscript == Chatscript.default([%{apn: "fake.apn.com"}])
+    modem_config = %{
+      service_providers: [%{apn: "fake.apn.com"}]
+    }
+
+    assert expected_chatscript == Chatscript.default(modem_config)
+  end
+
+  test "chatscript additions get inserted" do
+    expected_chatscript = """
+    ABORT 'BUSY'
+    ABORT 'NO CARRIER'
+    ABORT 'NO DIALTONE'
+    ABORT 'NO DIAL TONE'
+    ABORT 'NO ANSWER'
+    ABORT 'DELAYED'
+    TIMEOUT 10
+    REPORT CONNECT
+    "" +++
+    "" AT
+    OK ATH
+    OK ATZ
+    OK ATQ0
+    OK AT+CGDCONT=1,"IP","fake.apn.com"
+    OK AT+KSIMSEL=2
+    OK AT+KSIMSEL=3
+    OK ATDT*99***1#
+    CONNECT ''
+    """
+
+    modem_config = %{
+      service_providers: [%{apn: "fake.apn.com"}],
+      chatscript_additions: """
+      OK AT+KSIMSEL=2
+      OK AT+KSIMSEL=3
+      """
+    }
+
+    assert expected_chatscript == Chatscript.default(modem_config)
+
+    # Check iodata
+    modem_config = %{
+      service_providers: [%{apn: "fake.apn.com"}],
+      chatscript_additions: ["OK", " ", "AT+KSIMSEL=2", "\n", "OK", " ", "AT+KSIMSEL=3"]
+    }
+
+    assert expected_chatscript == Chatscript.default(modem_config)
+
+    # Check that modem chatscript additions come first
+    modem_config = %{
+      service_providers: [%{apn: "fake.apn.com"}],
+      chatscript_additions: "OK AT+KSIMSEL=3"
+    }
+
+    assert expected_chatscript == Chatscript.default(modem_config, "OK AT+KSIMSEL=2\n")
   end
 end


### PR DESCRIPTION
It's really useful to be able to add or override commands in the
chatscripts. This lets you do modem and application-specific things
without creating custom modem modules or adding little used features to
vintage_net_mobile.

Both modems and users can add lines to the chatscript. User additions
take precedence. I.e., modem-specific additions are listed first and
then user-provided ones are run. That allows users to override anything.
The additions happen immediately before the PPP connect step.

Here's an example configuration:

```elixir
    %{
      type: VintageNetMobile,
      modem: your_modem,
      vintage_net_mobile: %{
        service_providers: [
          %{apn: "wireless.twilio.com"}
        ],
        chatscript_additions: "OK AT+KSIMSEL=4"
      }
    }
```