### PR TITLE
Remove _ = on all Logger calls

### DIFF
--- a/lib/vintage_net_mobile/cell_monitor.ex
+++ b/lib/vintage_net_mobile/cell_monitor.ex
@@ -133,7 +133,7 @@ defmodule VintageNetMobile.CellMonitor do
   end
 
   defp creg_response_to_registration(malformed) do
-    _ = Logger.warn("Unexpected AT+CREG? response: #{inspect(malformed)}")
+    Logger.warn("Unexpected AT+CREG? response: #{inspect(malformed)}")
     %{stat: :invalid, lac: 0, ci: 0, act: 0}
   end
 
@@ -145,7 +145,7 @@ defmodule VintageNetMobile.CellMonitor do
   end
 
   defp qspn_response_to_network(malformed) do
-    _ = Logger.warn("Unexpected AT+QSPN response: #{inspect(malformed)}")
+    Logger.warn("Unexpected AT+QSPN response: #{inspect(malformed)}")
     %{network_name: "", mcc: 0, mnc: 0}
   end
 
@@ -155,7 +155,7 @@ defmodule VintageNetMobile.CellMonitor do
   end
 
   defp qnwinfo_response_to_info(malformed) do
-    _ = Logger.warn("Unexpected AT+QNWINFO response: #{inspect(malformed)}")
+    Logger.warn("Unexpected AT+QNWINFO response: #{inspect(malformed)}")
     %{act: "UNKNOWN", band: "", channel: 0}
   end
 

--- a/lib/vintage_net_mobile/ex_chat.ex
+++ b/lib/vintage_net_mobile/ex_chat.ex
@@ -78,7 +78,7 @@ defmodule VintageNetMobile.ExChat do
         :ok
 
       error ->
-        _ = Logger.warn("Send #{inspect(command)} failed: #{inspect(error)}. Ignoring...")
+        Logger.warn("Send #{inspect(command)} failed: #{inspect(error)}. Ignoring...")
         :ok
     end
   end
@@ -119,7 +119,7 @@ defmodule VintageNetMobile.ExChat do
         {:noreply, state}
 
       {:error, error} ->
-        _ = Logger.warn("vintage_net_mobile: can't open #{state.tty_name}: #{inspect(error)}")
+        Logger.warn("vintage_net_mobile: can't open #{state.tty_name}: #{inspect(error)}")
         Process.sleep(@error_delay)
         {:stop, :tty_error, state}
     end
@@ -149,12 +149,12 @@ defmodule VintageNetMobile.ExChat do
 
   @impl true
   def handle_info({:circuits_uart, tty_name, {:partial, fragment}}, state) do
-    _ = Logger.warn("vintage_net_mobile: dropping junk from #{tty_name}: #{inspect(fragment)}")
+    Logger.warn("vintage_net_mobile: dropping junk from #{tty_name}: #{inspect(fragment)}")
     {:noreply, state}
   end
 
   def handle_info({:circuits_uart, tty_name, {:error, error}}, state) do
-    _ = Logger.warn("vintage_net_mobile: error from #{tty_name}: #{inspect(error)}")
+    Logger.warn("vintage_net_mobile: error from #{tty_name}: #{inspect(error)}")
     Process.sleep(@error_delay)
     {:stop, :tty_error, state}
   end

--- a/lib/vintage_net_mobile/modem_info.ex
+++ b/lib/vintage_net_mobile/modem_info.ex
@@ -72,7 +72,7 @@ defmodule VintageNetMobile.ModemInfo do
   end
 
   defp iccid_response_to_qccid(anything_else) do
-    _ = Logger.warn("Unexpected AT+QCCID response: #{inspect(anything_else)}")
+    Logger.warn("Unexpected AT+QCCID response: #{inspect(anything_else)}")
     @unknown
   end
 
@@ -85,7 +85,7 @@ defmodule VintageNetMobile.ModemInfo do
   end
 
   defp cimi_response_to_imsi(anything_else) do
-    _ = Logger.warn("Unexpected AT+CIMI response: #{inspect(anything_else)}")
+    Logger.warn("Unexpected AT+CIMI response: #{inspect(anything_else)}")
     @unknown
   end
 

--- a/lib/vintage_net_mobile/pppd_notifications.ex
+++ b/lib/vintage_net_mobile/pppd_notifications.ex
@@ -19,7 +19,7 @@ defmodule VintageNetMobile.PPPDNotifications do
   """
   @impl true
   def ip_up(ifname, info) do
-    _ = Logger.debug("pppd.ip_up(#{ifname}): #{inspect(info)}")
+    Logger.debug("pppd.ip_up(#{ifname}): #{inspect(info)}")
 
     #  2:52:27.514 [error] ppp_to_elixir: dropping unknown report '{["ip-up", "ppp0", "/dev/ttyUSB0", "115200", "162.175.202.224", "10.64.64.64"],
     #  %{DEVICE: "/dev/ttyUSB0", DNS1: "10.177.0.34", DNS2: "10.177.0.210", IFNAME: "ppp0", IPLOCAL: "162.175.202.224", IPREMOTE: "10.64.64.64",
@@ -47,7 +47,7 @@ defmodule VintageNetMobile.PPPDNotifications do
   """
   @impl true
   def ip_down(ifname, info) do
-    _ = Logger.debug("pppd.ip_down(#{ifname}): #{inspect(info)}")
+    Logger.debug("pppd.ip_down(#{ifname}): #{inspect(info)}")
 
     RouteManager.clear_route(ifname)
     NameResolver.clear(ifname)

--- a/lib/vintage_net_mobile/signal_monitor.ex
+++ b/lib/vintage_net_mobile/signal_monitor.ex
@@ -88,7 +88,7 @@ defmodule VintageNetMobile.SignalMonitor do
   end
 
   defp csq_response_to_rssi(anything_else) do
-    _ = Logger.warn("Unexpected AT+CSQ response: #{inspect(anything_else)}")
+    Logger.warn("Unexpected AT+CSQ response: #{inspect(anything_else)}")
     @rssi_unknown
   end
 

--- a/lib/vintage_net_mobile/to_elixir/server.ex
+++ b/lib/vintage_net_mobile/to_elixir/server.ex
@@ -85,12 +85,10 @@ defmodule VintageNetMobile.ToElixir.Server do
   end
 
   defp dispatch({["ppp_to_elixir" | args], env}) do
-    _ = Logger.debug("ppp_to_elixir: Args=#{inspect(args)}, Env=#{inspect(env)}")
-    :ok
+    Logger.debug("ppp_to_elixir: Args=#{inspect(args)}, Env=#{inspect(env)}")
   end
 
   defp dispatch(unknown) do
-    _ = Logger.error("ppp_to_elixir: dropping unknown report '#{inspect(unknown)}''")
-    :ok
+    Logger.error("ppp_to_elixir: dropping unknown report '#{inspect(unknown)}''")
   end
 end


### PR DESCRIPTION
Elixir 1.10's Logger calls only return :ok now, so the return value no
longer needs to be ignored to make Dialyzer happy.