### PR TITLE
add note on ZTE MF833V modem

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Currently, it supports the following modems:
 * u-blox TOBY L2 - [`VintageNetMobile.Modem.UbloxTOBYL2`](https://www.u-blox.com/en/product/toby-l2-series)
 * Sierra Wireless HL8548 - [`VintageNetMobile.Modem.SierraHL8548`](https://source.sierrawireless.com/resources/airprime/hardware_specs_user_guides/airprime_hl8548_and_hl8548-g_product_technical_specification/)
 * Huawei E3372 - [`VintageNetMobile.Modem.HuaweiE3372`](https://consumer.huawei.com/en/routers/e3372/)
+* [ZTE MF833V] - does not need mobile driver, works with `VintageNetEthernet` when modem is configured to auto-connect
 
 See the "Custom Modems" section for adding new modules.
 


### PR DESCRIPTION
ZTE MF833V does not seem to need a special`VintageNetMobile` driver, but works with `VintageNetEthernet`. This PR adds a note to that effect to the readme.