### PR TITLE
Fix pppd shim to work with newer glibc versions

### DIFF
--- a/c_src/pppd_shim/Makefile
+++ b/c_src/pppd_shim/Makefile
@@ -19,7 +19,7 @@ BUILD  = $(MIX_APP_PATH)/obj/pppd_shim
 
 SHIM = $(PREFIX)/pppd_shim.so
 
-CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
+CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter
 LDFLAGS += -fPIC -shared -ldl
 CFLAGS += -fPIC
 

--- a/c_src/pppd_shim/pppd_shim.c
+++ b/c_src/pppd_shim/pppd_shim.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <stdarg.h>
+#include <features.h>
 
 #ifndef __APPLE__
 #define ORIGINAL(name) original_##name
@@ -56,11 +57,15 @@ static int fixup_path(const char *input, char *output)
 // and is executable. Then it calls execve. This shim only intercepts
 // those two library calls and modifies them to point to our priv
 // directory.
-
+#ifdef __GLIBC__
 #if __GLIBC_PREREQ(2, 33)
 #define OVERRIDE_STAT 1
 #else
 #define OVERRIDE_XSTAT 1
+#endif
+#else
+// If not using glibc, guess that stat should be overridden.
+#define OVERRIDE_STAT 1
 #endif
 
 #ifdef OVERRIDE_STAT


### PR DESCRIPTION
This updates the shim to override a the newer symbol used for stat when
running newer versions of glibc.

This was found when watching the pppd scripts successfully connect, but
the notifications didn't get to Elixir. Erlinit's test fixture is a much
more complicated shim than the one here and it had the fix to this.
