### PR TITLE
Create /var/run/pppd/lock if it doesn't exist

### DIFF
--- a/lib/vintage_net_mobile.ex
+++ b/lib/vintage_net_mobile.ex
@@ -144,8 +144,10 @@ defmodule VintageNetMobile do
 
   defp add_start_commands(raw_config, _modem) do
     # The mknod creates `/dev/ppp` if it doesn't exist.
+    # The mkdir creates `/var/run/pppd/lock` if it doesn't exist.
     new_up_cmds = [
-      {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]} | raw_config.up_cmds
+      {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]},
+      {:run_ignore_errors, "mkdir", ["-p", "/var/run/pppd/lock"]} | raw_config.up_cmds
     ]
 
     %RawConfig{raw_config | up_cmds: new_up_cmds}

--- a/test/vintage_net_mobile/modem/automatic_test.exs
+++ b/test/vintage_net_mobile/modem/automatic_test.exs
@@ -32,7 +32,8 @@ defmodule VintageNetMobile.Modem.AutomaticTest do
       source_config: input,
       required_ifnames: ["wwan0"],
       up_cmds: [
-        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
+        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]},
+        {:run_ignore_errors, "mkdir", ["-p", "/var/run/pppd/lock"]}
       ],
       down_cmds: [
         {:fun, PropertyTable, :delete_matches, [VintageNet, ["interface", "ppp0", "mobile"]]}

--- a/test/vintage_net_mobile/modem/quectel_BG96_test.exs
+++ b/test/vintage_net_mobile/modem/quectel_BG96_test.exs
@@ -33,7 +33,8 @@ defmodule VintageNetMobile.Modem.QuectelBG96Test do
       source_config: input,
       required_ifnames: ["wwan0"],
       up_cmds: [
-        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
+        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]},
+        {:run_ignore_errors, "mkdir", ["-p", "/var/run/pppd/lock"]}
       ],
       down_cmds: [
         {:fun, PropertyTable, :delete_matches, [VintageNet, ["interface", "ppp0", "mobile"]]}
@@ -109,7 +110,8 @@ defmodule VintageNetMobile.Modem.QuectelBG96Test do
       source_config: input,
       required_ifnames: ["wwan0"],
       up_cmds: [
-        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
+        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]},
+        {:run_ignore_errors, "mkdir", ["-p", "/var/run/pppd/lock"]}
       ],
       down_cmds: [
         {:fun, PropertyTable, :delete_matches, [VintageNet, ["interface", "ppp0", "mobile"]]}
@@ -184,7 +186,8 @@ defmodule VintageNetMobile.Modem.QuectelBG96Test do
       source_config: input,
       required_ifnames: ["wwan0"],
       up_cmds: [
-        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
+        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]},
+        {:run_ignore_errors, "mkdir", ["-p", "/var/run/pppd/lock"]}
       ],
       down_cmds: [
         {:fun, PropertyTable, :delete_matches, [VintageNet, ["interface", "ppp0", "mobile"]]}

--- a/test/vintage_net_mobile/modem/quectel_EC25_test.exs
+++ b/test/vintage_net_mobile/modem/quectel_EC25_test.exs
@@ -21,7 +21,8 @@ defmodule VintageNetMobile.Modem.QuectelEC25Test do
       source_config: input,
       required_ifnames: ["wwan0"],
       up_cmds: [
-        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
+        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]},
+        {:run_ignore_errors, "mkdir", ["-p", "/var/run/pppd/lock"]}
       ],
       down_cmds: [
         {:fun, PropertyTable, :delete_matches, [VintageNet, ["interface", "ppp0", "mobile"]]}
@@ -93,7 +94,8 @@ defmodule VintageNetMobile.Modem.QuectelEC25Test do
       source_config: input,
       required_ifnames: ["wwan0"],
       up_cmds: [
-        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
+        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]},
+        {:run_ignore_errors, "mkdir", ["-p", "/var/run/pppd/lock"]}
       ],
       down_cmds: [
         {:fun, PropertyTable, :delete_matches, [VintageNet, ["interface", "ppp0", "mobile"]]}

--- a/test/vintage_net_mobile/modem/sierra_HL8548_test.exs
+++ b/test/vintage_net_mobile/modem/sierra_HL8548_test.exs
@@ -21,7 +21,8 @@ defmodule VintageNetMobile.Modem.SierraHL8548Test do
       source_config: input,
       required_ifnames: ["wwan0"],
       up_cmds: [
-        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
+        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]},
+        {:run_ignore_errors, "mkdir", ["-p", "/var/run/pppd/lock"]}
       ],
       down_cmds: [
         {:fun, PropertyTable, :delete_matches, [VintageNet, ["interface", "ppp0", "mobile"]]}

--- a/test/vintage_net_mobile/modem/telit_le910_test.exs
+++ b/test/vintage_net_mobile/modem/telit_le910_test.exs
@@ -21,7 +21,8 @@ defmodule VintageNetMobile.Modem.TelitLE910Test do
       source_config: input,
       required_ifnames: ["wwan0"],
       up_cmds: [
-        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
+        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]},
+        {:run_ignore_errors, "mkdir", ["-p", "/var/run/pppd/lock"]}
       ],
       down_cmds: [
         {:fun, PropertyTable, :delete_matches, [VintageNet, ["interface", "ppp0", "mobile"]]}

--- a/test/vintage_net_mobile/modem/ublox_TOBY_L2_test.exs
+++ b/test/vintage_net_mobile/modem/ublox_TOBY_L2_test.exs
@@ -24,7 +24,8 @@ defmodule VintageNetMobile.Modem.UbloxTOBYL2Test do
       source_config: input,
       required_ifnames: ["wwan0"],
       up_cmds: [
-        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
+        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]},
+        {:run_ignore_errors, "mkdir", ["-p", "/var/run/pppd/lock"]}
       ],
       down_cmds: [
         {:fun, PropertyTable, :delete_matches, [VintageNet, ["interface", "ppp0", "mobile"]]}

--- a/test/vintage_net_mobile_test.exs
+++ b/test/vintage_net_mobile_test.exs
@@ -45,7 +45,8 @@ defmodule VintageNetMobileTest do
       required_ifnames: ["wwan0"],
       files: [{"chatscript.ppp0", "The service providers are [%{apn: \"free_lte\"}]"}],
       up_cmds: [
-        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]}
+        {:run_ignore_errors, "mknod", ["/dev/ppp", "c", "108", "0"]},
+        {:run_ignore_errors, "mkdir", ["-p", "/var/run/pppd/lock"]}
       ],
       down_cmds: [
         {:fun, PropertyTable, :delete_matches, [VintageNet, ["interface", "ppp0", "mobile"]]}


### PR DESCRIPTION
pppd should be creating this directory, but is not:
```
00:00:10.855 [error] Jul 25 00:00:10  pppd[162]: Can't create lock file /var/run/pppd/lock/LCK..ttyUSB2: No such file or directory
```
Create the directory `/var/run/ppd/lock` if it doesn't exist