### PR TITLE
Initial ECM and EG915Q modem support

### DIFF
--- a/lib/vintage_net_mobile/modem/quectel_EG915Q.ex
+++ b/lib/vintage_net_mobile/modem/quectel_EG915Q.ex
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2020 Frank Hunleth
+# SPDX-FileCopyrightText: 2022 Matt Ludwigs
+# SPDX-FileCopyrightText: 2023 Masatoshi Nishiguchi
+# SPDX-FileCopyrightText: 2026 Digit
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule VintageNetMobile.Modem.QuectelEG915Q do
+  @behaviour VintageNetMobile.Modem
+
+  require Logger
+
+  @moduledoc """
+  Quectel EG915Q support
+
+  This modem is a special case, it does not support PPP but instead provides an Ethernet-over-USB interface.
+  When configured, AT commands will be sent to the modem to set up the APN and USB network interface.
+  The modem will handle the actual connection itself and udhcpc will be used to get an IP address.
+
+  The Quectel EG915Q is an LTE Cat 1 Bis module.
+
+  Example configuration:
+
+  ```elixir
+  VintageNet.configure(
+    "usb0",
+    %{
+      type: VintageNetMobile,
+      vintage_net_mobile: %{
+        modem: VintageNetMobile.Modem.QuectelEG915Q,
+        service_providers: [%{apn: "super"}]
+      }
+    }
+  )
+  ```
+
+  Options:
+
+  * `:modem` - `VintageNetMobile.Modem.QuectelEG915Q`
+  * `:service_providers` - A list of service provider information (only `:apn`
+    providers are supported)
+  * `:at_tty` - A tty for sending AT commands on. This defaults to `"ttyUSB2"`
+    which works unless other USB serial devices cause Linux to set it to
+    something different.
+
+  If multiple service providers are configured, this implementation only
+  attempts to connect to the first one.
+  """
+
+  alias VintageNet.Command
+  alias VintageNetMobile.ModemECM
+  alias VintageNetMobile.{CellMonitor, ExChat, ModemInfo, SignalMonitor}
+  alias VintageNetMobile.Modem.Utils
+
+  @impl VintageNetMobile.Modem
+  def normalize(config) do
+    config
+    |> Utils.require_a_service_provider()
+  end
+
+  @impl VintageNetMobile.Modem
+  def add_raw_config(raw_config, %{vintage_net_mobile: mobile} = _config, _opts) do
+    ifname = raw_config.ifname
+    at_tty = Map.get(mobile, :at_tty, "ttyUSB2")
+    {:ok, hostname} = :inet.gethostname()
+
+    child_specs = [
+      {ExChat, [tty: at_tty, speed: 9600]},
+      {ModemECM, [ifname: ifname, tty: at_tty, apn: hd(mobile.service_providers).apn]},
+      {SignalMonitor, [ifname: ifname, tty: at_tty]},
+      {CellMonitor, [ifname: ifname, tty: at_tty]},
+      {ModemInfo, [ifname: ifname, tty: at_tty]},
+      Supervisor.child_spec(
+        {VintageNet.Interface.IfupDaemon,
+         [
+           ifname: ifname,
+           command: "udhcpc",
+           args: [
+             "-f",
+             "-i",
+             ifname,
+             "-x",
+             "hostname:#{hostname}",
+             "-s",
+             BEAMNotify.bin_path()
+           ],
+           opts:
+             Command.add_muon_options(
+               stderr_to_stdout: true,
+               log_output: :debug,
+               log_prefix: "udhcpc(#{ifname}): ",
+               env: BEAMNotify.env(name: "vintage_net_comm", report_env: true)
+             )
+         ]},
+        id: :udhcpc
+      ),
+      {VintageNet.Connectivity.InternetChecker, ifname}
+    ]
+
+    Logger.info("#{inspect(raw_config)}")
+
+    new_up_cmds = raw_config.up_cmds ++ [{:run, "ip", ["link", "set", ifname, "up"]}]
+
+    new_down_cmds =
+      raw_config.down_cmds ++
+        [
+          {:run_ignore_errors, "ip", ["addr", "flush", "dev", ifname, "label", ifname]},
+          {:run, "ip", ["link", "set", ifname, "down"]}
+        ]
+
+    %{raw_config | up_cmds: new_up_cmds, down_cmds: new_down_cmds}
+
+    %{
+      raw_config
+      | child_specs: child_specs,
+        up_cmds: new_up_cmds,
+        down_cmds: new_down_cmds
+    }
+  end
+end

--- a/lib/vintage_net_mobile/modem_ecm.ex
+++ b/lib/vintage_net_mobile/modem_ecm.ex
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2020 Frank Hunleth
+# SPDX-FileCopyrightText: 2022 Matt Ludwigs
+# SPDX-FileCopyrightText: 2023 Masatoshi Nishiguchi
+# SPDX-FileCopyrightText: 2026 Digit
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule VintageNetMobile.ModemECM do
+  use GenServer
+  require Logger
+  alias VintageNetMobile.ExChat
+
+  defmodule State do
+    @moduledoc false
+
+    defstruct ifname: nil, tty: nil, apn: nil, ready: false, phase: nil
+  end
+
+  @spec start_link([keyword()]) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    ifname = Keyword.fetch!(opts, :ifname)
+    tty = Keyword.fetch!(opts, :tty)
+    apn = Keyword.fetch!(opts, :apn)
+
+    us = self()
+
+    ExChat.register(tty, "+QNETDEVSTATUS", fn message ->
+      send(us, {:handle_dev_status, message})
+    end)
+
+    Process.send_after(us, :setup_modem, 500)
+
+    {:ok, %State{ifname: ifname, tty: tty, apn: apn, ready: false, phase: :liveness_check}}
+  end
+
+  @impl GenServer
+  def handle_info(:setup_modem, %{phase: :liveness_check} = state) do
+    Logger.debug("Checking Modem liveness...")
+
+    case ExChat.send(state.tty, "AT") do
+      {:ok, _} ->
+        ExChat.send_best_effort(state.tty, "ATH")
+        ExChat.send_best_effort(state.tty, "ATZ")
+        ExChat.send_best_effort(state.tty, "ATQ0")
+        Process.send_after(self(), :setup_modem, 500)
+        {:noreply, %{state | phase: :apn_setup}}
+
+      _ ->
+        Process.send_after(self(), :setup_modem, 500)
+        {:noreply, state}
+    end
+  end
+
+  def handle_info(:setup_modem, %{phase: :apn_setup} = state) do
+    Logger.debug("Setting modem APN...")
+
+    cmd = "AT+CGDCONT=1,\"IP\",\"#{state.apn}\""
+
+    case ExChat.send(state.tty, cmd) do
+      {:ok, _} ->
+        Process.send_after(self(), :setup_modem, 500)
+        {:noreply, %{state | phase: :usb_net_config}}
+
+      _ ->
+        Process.send_after(self(), :setup_modem, 500)
+        {:noreply, state}
+    end
+  end
+
+  def handle_info(:setup_modem, %{phase: :usb_net_config} = state) do
+    Logger.debug("Setting up modem USBNET...")
+
+    with {:ok, _} <- ExChat.send(state.tty, "AT+QCFG=\"usbnet\",1") do
+      Logger.debug("Modem configured for USBNET (ECM), starting data session...")
+      ExChat.send_best_effort(state.tty, "AT+QNETDEVCTL=1,1,1")
+      {:noreply, %{state | phase: :done}}
+    else
+      _ ->
+        Process.send_after(self(), :setup_modem, 500)
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:handle_dev_status, message}, state) do
+    if message == "+QNETDEVSTATUS: 1" do
+      Logger.debug("USBNET set complete!")
+      {:noreply, %{state | ready: true}, :hibernate}
+    else
+      Logger.error(
+        "Unexpected QNETDEVSTATUS from modem: #{message}, retying configuration in 10 seconds"
+      )
+
+      Process.send_after(self(), :setup_modem, 10_000)
+      {:noreply, %{state | phase: :liveness_check}}
+    end
+  end
+end


### PR DESCRIPTION
* Adds initial support for ECM modems:
 * A child is started along side the modem module which configures the modem to use ECM mode and sets up the APN
 * Adds up/down commands to the interface to use DHCP

This is a first pass, feedback welcome.